### PR TITLE
Core 1.4.0: Networking Cleanup

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "@runejs/core",
-    "version": "1.3.2",
+    "version": "1.4.0",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {
@@ -10,20 +10,30 @@
             "integrity": "sha512-WEezM1FWztfbzqIUbsDzFRVMxSoLy3HugVcux6KDDtTqzPsLE8NDRHfXvev66aH1i2oOKKar3/XDjbvh/OUBdg=="
         },
         "@types/node": {
-            "version": "14.14.37",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.37.tgz",
-            "integrity": "sha512-XYmBiy+ohOR4Lh5jE379fV2IU+6Jn4g5qASinhitfyO71b/sCo6MKsMLF5tc7Zf2CE8hViVQyYSobJNke8OvUw==",
+            "version": "14.17.6",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-14.17.6.tgz",
+            "integrity": "sha512-iBxsxU7eswQDGhlr3AiamBxOssaYxbM+NKXVil8jg9yFXvrfEFbDumLD/2dMTB+zYyg7w+Xjt8yuxfdbUHAtcQ==",
             "dev": true
         },
         "@types/pino": {
-            "version": "6.3.6",
-            "resolved": "https://registry.npmjs.org/@types/pino/-/pino-6.3.6.tgz",
-            "integrity": "sha512-yVgSyMGzNDYe/XNMJyuIkklDeZbFdGAxRztYLoN1QQrrgiLJ1oJPmnS8Ge5xpzI9ODKEddKH97VFQ7cWO6Pumw==",
+            "version": "6.3.11",
+            "resolved": "https://registry.npmjs.org/@types/pino/-/pino-6.3.11.tgz",
+            "integrity": "sha512-S7+fLONqSpHeW9d7TApUqO6VN47KYgOXhCNKwGBVLHObq8HhaAYlVqUNdfnvoXjCMiwE5xcPm/5R2ZUh8bgaXQ==",
             "dev": true,
             "requires": {
                 "@types/node": "*",
+                "@types/pino-pretty": "*",
                 "@types/pino-std-serializers": "*",
-                "@types/sonic-boom": "*"
+                "sonic-boom": "^2.1.0"
+            }
+        },
+        "@types/pino-pretty": {
+            "version": "4.7.1",
+            "resolved": "https://registry.npmjs.org/@types/pino-pretty/-/pino-pretty-4.7.1.tgz",
+            "integrity": "sha512-l1ntNXdpVWsnPYUk5HyO5Lxfr38zLCgxVfEn/9Zhhm+nGF04/BiIou/m8XPwvoVZLV+livUo79VdHXMJPfUYxA==",
+            "dev": true,
+            "requires": {
+                "@types/pino": "*"
             }
         },
         "@types/pino-std-serializers": {
@@ -35,21 +45,12 @@
                 "@types/node": "*"
             }
         },
-        "@types/sonic-boom": {
-            "version": "0.7.0",
-            "resolved": "https://registry.npmjs.org/@types/sonic-boom/-/sonic-boom-0.7.0.tgz",
-            "integrity": "sha512-AfqR0fZMoUXUNwusgXKxcE9DPlHNDHQp6nKYUd4PSRpLobF5CCevSpyTEBcVZreqaWKCnGBr9KI1fHMTttoB7A==",
-            "dev": true,
-            "requires": {
-                "@types/node": "*"
-            }
-        },
         "ansi-styles": {
-            "version": "3.2.1",
-            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-            "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+            "version": "4.3.0",
+            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+            "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
             "requires": {
-                "color-convert": "^1.9.0"
+                "color-convert": "^2.0.1"
             }
         },
         "arg": {
@@ -77,6 +78,14 @@
                 "mri": "1.1.4"
             },
             "dependencies": {
+                "ansi-styles": {
+                    "version": "3.2.1",
+                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+                    "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+                    "requires": {
+                        "color-convert": "^1.9.0"
+                    }
+                },
                 "chalk": {
                     "version": "2.4.2",
                     "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
@@ -86,6 +95,32 @@
                         "escape-string-regexp": "^1.0.5",
                         "supports-color": "^5.3.0"
                     }
+                },
+                "color-convert": {
+                    "version": "1.9.3",
+                    "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+                    "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+                    "requires": {
+                        "color-name": "1.1.3"
+                    }
+                },
+                "color-name": {
+                    "version": "1.1.3",
+                    "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+                    "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
+                },
+                "has-flag": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+                    "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
+                },
+                "supports-color": {
+                    "version": "5.5.0",
+                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+                    "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+                    "requires": {
+                        "has-flag": "^3.0.0"
+                    }
                 }
             }
         },
@@ -93,6 +128,22 @@
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/atomic-sleep/-/atomic-sleep-1.0.0.tgz",
             "integrity": "sha512-kNOjDqAh7px0XWNI+4QbzoiR/nTkHAWNud2uvnJquD1/x5a7EQZMJT0AczqK0Qn67oY/TTQ1LbUKajZpp3I9tQ=="
+        },
+        "balanced-match": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+            "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+            "dev": true
+        },
+        "brace-expansion": {
+            "version": "1.1.11",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+            "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+            "dev": true,
+            "requires": {
+                "balanced-match": "^1.0.0",
+                "concat-map": "0.0.1"
+            }
         },
         "buffer-from": {
             "version": "1.1.1",
@@ -106,62 +157,32 @@
             "integrity": "sha512-faqwZqnWxbxn+F1d399ygeamQNy3lPp/H9H6rNrqYh4FSVCtcY+3cub1MxA8o9mDd55mM8Aghuu/kuyYA6VTsA=="
         },
         "chalk": {
-            "version": "4.1.0",
-            "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
-            "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
+            "version": "4.1.1",
+            "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.1.tgz",
+            "integrity": "sha512-diHzdDKxcU+bAsUboHLPEDQiw0qEe0qd7SYUn3HgcFlWgbDcfLGswOHYeGrHKzG9z6UYf01d9VFMfZxPM1xZSg==",
             "requires": {
                 "ansi-styles": "^4.1.0",
                 "supports-color": "^7.1.0"
-            },
-            "dependencies": {
-                "ansi-styles": {
-                    "version": "4.3.0",
-                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-                    "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-                    "requires": {
-                        "color-convert": "^2.0.1"
-                    }
-                },
-                "color-convert": {
-                    "version": "2.0.1",
-                    "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-                    "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-                    "requires": {
-                        "color-name": "~1.1.4"
-                    }
-                },
-                "color-name": {
-                    "version": "1.1.4",
-                    "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-                    "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
-                },
-                "has-flag": {
-                    "version": "4.0.0",
-                    "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-                    "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
-                },
-                "supports-color": {
-                    "version": "7.2.0",
-                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-                    "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-                    "requires": {
-                        "has-flag": "^4.0.0"
-                    }
-                }
             }
         },
         "color-convert": {
-            "version": "1.9.3",
-            "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
-            "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+            "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
             "requires": {
-                "color-name": "1.1.3"
+                "color-name": "~1.1.4"
             }
         },
         "color-name": {
-            "version": "1.1.3",
-            "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-            "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
+            "version": "1.1.4",
+            "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+            "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+        },
+        "concat-map": {
+            "version": "0.0.1",
+            "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+            "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+            "dev": true
         },
         "create-require": {
             "version": "1.1.1",
@@ -199,24 +220,54 @@
             "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A=="
         },
         "fast-redact": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/fast-redact/-/fast-redact-3.0.0.tgz",
-            "integrity": "sha512-a/S/Hp6aoIjx7EmugtzLqXmcNsyFszqbt6qQ99BdG61QjBZF6shNis0BYR6TsZOQ1twYc0FN2Xdhwwbv6+KD0w=="
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/fast-redact/-/fast-redact-3.0.1.tgz",
+            "integrity": "sha512-kYpn4Y/valC9MdrISg47tZOpYBNoTXKgT9GYXFpHN/jYFs+lFkPoisY+LcBODdKVMY96ATzvzsWv+ES/4Kmufw=="
         },
         "fast-safe-stringify": {
-            "version": "2.0.7",
-            "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.0.7.tgz",
-            "integrity": "sha512-Utm6CdzT+6xsDk2m8S6uL8VHxNwI6Jub+e9NYTcAms28T84pTa25GJQV9j0CY0N1rM8hK4x6grpF2BQf+2qwVA=="
+            "version": "2.0.8",
+            "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.0.8.tgz",
+            "integrity": "sha512-lXatBjf3WPjmWD6DpIZxkeSsCOwqI0maYMpgDlx8g4U2qi4lbjA9oH/HD2a87G+KfsUmo5WbJFmqBZlPxtptag=="
         },
         "flatstr": {
             "version": "1.0.12",
             "resolved": "https://registry.npmjs.org/flatstr/-/flatstr-1.0.12.tgz",
             "integrity": "sha512-4zPxDyhCyiN2wIAtSLI6gc82/EjqZc1onI4Mz/l0pWrAlsSfYH/2ZIcU+e3oA2wDwbzIWNKwa23F8rh6+DRWkw=="
         },
+        "fs.realpath": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+            "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+            "dev": true
+        },
+        "glob": {
+            "version": "7.1.7",
+            "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.7.tgz",
+            "integrity": "sha512-OvD9ENzPLbegENnYP5UUfJIirTg4+XwMWGaQfQTY0JenxNvvIKP3U3/tAQSPIu/lHxXYSZmpXlUHeqAIdKzBLQ==",
+            "dev": true,
+            "requires": {
+                "fs.realpath": "^1.0.0",
+                "inflight": "^1.0.4",
+                "inherits": "2",
+                "minimatch": "^3.0.4",
+                "once": "^1.3.0",
+                "path-is-absolute": "^1.0.0"
+            }
+        },
         "has-flag": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-            "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+            "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
+        },
+        "inflight": {
+            "version": "1.0.6",
+            "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+            "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+            "dev": true,
+            "requires": {
+                "once": "^1.3.0",
+                "wrappy": "1"
+            }
         },
         "inherits": {
             "version": "2.0.4",
@@ -234,9 +285,9 @@
             "integrity": "sha512-YqvUxoOcVPnCp0VU1/56f+iKSdvIRJYPznH22BdXV3xMk75SFXhWeJkZ8C9XxUWt1b5x2X1SxuFygW1U0FmkEQ=="
         },
         "js-yaml": {
-            "version": "3.14.0",
-            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.0.tgz",
-            "integrity": "sha512-/4IbIeHcD9VMHFqDR/gQ7EdZdLimOvW2DdcxFjdyyZ9NsbS+ccrXqVWDtab/lRl5AlUqmpBx8EhPaWR+OtY17A==",
+            "version": "3.14.1",
+            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
+            "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
             "requires": {
                 "argparse": "^1.0.7",
                 "esprima": "^4.0.0"
@@ -253,6 +304,15 @@
             "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
             "dev": true
         },
+        "minimatch": {
+            "version": "3.0.4",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+            "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+            "dev": true,
+            "requires": {
+                "brace-expansion": "^1.1.7"
+            }
+        },
         "mri": {
             "version": "1.1.4",
             "resolved": "https://registry.npmjs.org/mri/-/mri-1.1.4.tgz",
@@ -266,23 +326,40 @@
                 "wrappy": "1"
             }
         },
+        "path-is-absolute": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+            "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+            "dev": true
+        },
         "pino": {
-            "version": "6.11.2",
-            "resolved": "https://registry.npmjs.org/pino/-/pino-6.11.2.tgz",
-            "integrity": "sha512-bmzxwbrIPxQUlAuMkF4PWVErUGERU4z37HazlhflKFg08crsNE3fACGN6gPwg5xtKOK47Ux5cZm8YCuLV4wWJg==",
+            "version": "6.13.0",
+            "resolved": "https://registry.npmjs.org/pino/-/pino-6.13.0.tgz",
+            "integrity": "sha512-mRXSTfa34tbfrWqCIp1sUpZLqBhcoaGapoyxfEwaWwJGMpLijlRdDKIQUyvq4M3DUfFH5vEglwSw8POZYwbThA==",
             "requires": {
                 "fast-redact": "^3.0.0",
-                "fast-safe-stringify": "^2.0.7",
+                "fast-safe-stringify": "^2.0.8",
                 "flatstr": "^1.0.12",
                 "pino-std-serializers": "^3.1.0",
-                "quick-format-unescaped": "4.0.1",
+                "quick-format-unescaped": "^4.0.3",
                 "sonic-boom": "^1.0.2"
+            },
+            "dependencies": {
+                "sonic-boom": {
+                    "version": "1.4.1",
+                    "resolved": "https://registry.npmjs.org/sonic-boom/-/sonic-boom-1.4.1.tgz",
+                    "integrity": "sha512-LRHh/A8tpW7ru89lrlkU4AszXt1dbwSjVWguGrmlxE7tawVmDBlI1PILMkXAxJTwqhgsEeTHzj36D5CmHgQmNg==",
+                    "requires": {
+                        "atomic-sleep": "^1.0.0",
+                        "flatstr": "^1.0.12"
+                    }
+                }
             }
         },
         "pino-pretty": {
-            "version": "4.7.1",
-            "resolved": "https://registry.npmjs.org/pino-pretty/-/pino-pretty-4.7.1.tgz",
-            "integrity": "sha512-ILE5YBpur88FlZ0cr1BNqVjgG9fOoK+md3peqmcs7AC6oq7SNiaJioIcrykMxfNsuygMYjUJtvAcARRE9aRc9w==",
+            "version": "4.8.0",
+            "resolved": "https://registry.npmjs.org/pino-pretty/-/pino-pretty-4.8.0.tgz",
+            "integrity": "sha512-mhQfHG4rw5ZFpWL44m0Utjo4GC2+HMfdNvxyA8lLw0sIqn6fCf7uQe6dPckUcW/obly+OQHD7B/MTso6LNizYw==",
             "requires": {
                 "@hapi/bourne": "^2.0.0",
                 "args": "^5.0.1",
@@ -293,6 +370,7 @@
                 "joycon": "^2.2.5",
                 "pump": "^3.0.0",
                 "readable-stream": "^3.6.0",
+                "rfdc": "^1.3.0",
                 "split2": "^3.1.1",
                 "strip-json-comments": "^3.1.1"
             }
@@ -312,9 +390,9 @@
             }
         },
         "quick-format-unescaped": {
-            "version": "4.0.1",
-            "resolved": "https://registry.npmjs.org/quick-format-unescaped/-/quick-format-unescaped-4.0.1.tgz",
-            "integrity": "sha512-RyYpQ6Q5/drsJyOhrWHYMWTedvjTIat+FTwv0K4yoUxzvekw2aRHMQJLlnvt8UantkZg2++bEzD9EdxXqkWf4A=="
+            "version": "4.0.3",
+            "resolved": "https://registry.npmjs.org/quick-format-unescaped/-/quick-format-unescaped-4.0.3.tgz",
+            "integrity": "sha512-MaL/oqh02mhEo5m5J2rwsVL23Iw2PEaGVHgT2vFt8AAsr0lfvQA5dpXo9TPu0rz7tSBdUPgkbam0j/fj5ZM8yg=="
         },
         "readable-stream": {
             "version": "3.6.0",
@@ -326,18 +404,32 @@
                 "util-deprecate": "^1.0.1"
             }
         },
+        "rfdc": {
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/rfdc/-/rfdc-1.3.0.tgz",
+            "integrity": "sha512-V2hovdzFbOi77/WajaSMXk2OLm+xNIeQdMMuB7icj7bk6zi2F8GGAxigcnDFpJHbNyNcgyJDiP+8nOrY5cZGrA=="
+        },
+        "rimraf": {
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+            "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+            "dev": true,
+            "requires": {
+                "glob": "^7.1.3"
+            }
+        },
         "safe-buffer": {
             "version": "5.2.1",
             "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
             "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
         },
         "sonic-boom": {
-            "version": "1.4.1",
-            "resolved": "https://registry.npmjs.org/sonic-boom/-/sonic-boom-1.4.1.tgz",
-            "integrity": "sha512-LRHh/A8tpW7ru89lrlkU4AszXt1dbwSjVWguGrmlxE7tawVmDBlI1PILMkXAxJTwqhgsEeTHzj36D5CmHgQmNg==",
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/sonic-boom/-/sonic-boom-2.1.0.tgz",
+            "integrity": "sha512-x2j9LXx27EDlyZEC32gBM+scNVMdPutU7FIKV2BOTKCnPrp7bY5BsplCMQ4shYYR3IhDSIrEXoqb6GlS+z7KyQ==",
+            "dev": true,
             "requires": {
-                "atomic-sleep": "^1.0.0",
-                "flatstr": "^1.0.12"
+                "atomic-sleep": "^1.0.0"
             }
         },
         "source-map": {
@@ -383,11 +475,11 @@
             "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig=="
         },
         "supports-color": {
-            "version": "5.5.0",
-            "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-            "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+            "version": "7.2.0",
+            "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+            "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
             "requires": {
-                "has-flag": "^3.0.0"
+                "has-flag": "^4.0.0"
             }
         },
         "ts-node": {
@@ -405,14 +497,16 @@
             }
         },
         "tslib": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.1.0.tgz",
-            "integrity": "sha512-hcVC3wYEziELGGmEEXue7D75zbwIIVUMWAVbHItGPx0ziyXxrOMQx4rQEVEV45Ut/1IotuEvwqPopzIOkDMf0A=="
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.0.tgz",
+            "integrity": "sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg==",
+            "dev": true
         },
         "typescript": {
-            "version": "4.2.3",
-            "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.2.3.tgz",
-            "integrity": "sha512-qOcYwxaByStAWrBf4x0fibwZvMRG+r4cQoTjbPtUlrWjBHbmCAww1i448U0GJ+3cNNEtebDteo/cHOR3xJ4wEw=="
+            "version": "4.3.5",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.3.5.tgz",
+            "integrity": "sha512-DqQgihaQ9cUrskJo9kIyW/+g0Vxsk8cDtZ52a3NGh0YNTfpUSArXSohyUGnvbPazEPLu398C0UxmKSOrPumUzA==",
+            "dev": true
         },
         "util-deprecate": {
             "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -1,14 +1,16 @@
 {
     "name": "@runejs/core",
-    "version": "1.3.2",
+    "version": "1.4.0",
     "description": "Core logging, networking, and buffer functionality for RuneJS applications.",
-    "main": "index.js",
-    "types": "index.d.ts",
+    "main": "dist/index.js",
+    "types": "dist/index.d.ts",
     "scripts": {
         "build": "tsc",
         "start": "ts-node src/test.ts",
         "copy-documents": "cp package.json dist && cp README.md dist && cp .npmignore dist && cp LICENSE dist",
-        "package": "rm -rf dist && npm run build && npm run copy-documents && cd dist && npm publish --dry-run"
+        "copy-documents:windows": "copy package.json dist && copy README.md dist && copy .npmignore dist && copy LICENSE dist",
+        "package": "rimraf dist && npm run build && npm run copy-documents && cd dist && npm publish --dry-run",
+        "package:windows": "rimraf dist && npm run build && npm run copy-documents:windows && cd dist && npm publish --dry-run"
     },
     "repository": {
         "type": "git",
@@ -21,15 +23,19 @@
     },
     "homepage": "https://github.com/runejs/core#readme",
     "dependencies": {
-        "js-yaml": "^3.14.0",
-        "pino": "^6.11.2",
-        "pino-pretty": "^4.7.1",
-        "tslib": "^2.1.0",
-        "typescript": "^4.2.3"
+        "js-yaml": "^3.14.1",
+        "pino": "^6.13.0",
+        "pino-pretty": "^4.8.0"
     },
     "devDependencies": {
-        "@types/node": "^14.14.37",
-        "@types/pino": "^6.3.6",
-        "ts-node": "^9.1.1"
+        "@types/node": "^14.17.6",
+        "@types/pino": "^6.3.11",
+        "rimraf": "^3.0.2",
+        "ts-node": "^9.1.1",
+        "tslib": ">=2.1.0",
+        "typescript": ">=4.2.0"
+    },
+    "peerDependencies": {
+        "tslib": ">=2.1.0"
     }
 }

--- a/src/buffer/byte-buffer.ts
+++ b/src/buffer/byte-buffer.ts
@@ -1,7 +1,9 @@
+import { Buffer } from 'buffer';
+import { logger } from '../logger';
 
 export type DataType =
-    'BYTE' | 'SHORT' | 'SMART' | 'INT24' | 'INT' | 'LONG' |
-    'byte' | 'short' | 'smart' | 'int24' | 'int' | 'long';
+    'BYTE' | 'SHORT' | 'SMART' | 'INT24' | 'INT' | 'LONG' | 'STRING' |
+    'byte' | 'short' | 'smart' | 'int24' | 'int' | 'long' | 'string';
 
 export type Endianness =
     'LITTLE_ENDIAN' | 'BIG_ENDIAN' | 'MIDDLE_ENDIAN_1' | 'MIDDLE_ENDIAN_2' |
@@ -11,41 +13,41 @@ export type Endianness =
 export type Signedness =
     'SIGNED' | 'UNSIGNED' |
     'signed' | 'unsigned' |
-    's' | 'u';
+    's' | 'u' | 'S' | 'U';
 
 
 export const MAX_SIGNED_LENGTHS = {
-    'BYTE': 127,
-    'SHORT': 32767,
-    'SMART': -1,
-    'INT24': 8388607,
-    'INT': 2147483647,
-    'LONG': BigInt('9223372036854775807')
+    'byte': 127,
+    'short': 32767,
+    'smart': -1,
+    'int24': 8388607,
+    'int': 2147483647,
+    'long': BigInt('9223372036854775807')
 };
 
 export const BYTE_LENGTH = {
-    'BYTE': 1,
-    'SHORT': 2,
-    'SMART': -1,
-    'INT24': 3,
-    'INT': 4,
-    'LONG': 8
+    'byte': 1,
+    'short': 2,
+    'smart': -1,
+    'int24': 3,
+    'int': 4,
+    'long': 8
 };
 
 export const BIT_LENGTH = {
-    'BYTE': 8,
-    'SHORT': 16,
-    'SMART': -1,
-    'INT24': 24,
-    'INT': 32,
-    'LONG': 64
+    'byte': 8,
+    'short': 16,
+    'smart': -1,
+    'int24': 24,
+    'int': 32,
+    'long': 64
 };
 
 export const ENDIAN_SUFFIX = {
-    'LITTLE_ENDIAN': 'LE',
-    'BIG_ENDIAN': 'BE',
-    'MIDDLE_ENDIAN_1': 'ME1',
-    'MIDDLE_ENDIAN_2': 'ME2'
+    'little_endian': 'LE',
+    'big_endian': 'BE',
+    'middle_endian_1': 'ME1',
+    'middle_endian_2': 'ME2'
 };
 
 const BIT_MASKS: number[] = [];
@@ -58,83 +60,117 @@ export class ByteBuffer extends Uint8Array {
 
     private _writerIndex: number = 0;
     private _readerIndex: number = 0;
-    private bitIndex: number;
+    private _bitIndex: number;
 
-    public static getSignage(signed: Signedness): string {
-        return signed.length === 1 ? signed.toUpperCase() : signed.toUpperCase().charAt(0);
+    public static getType(type: DataType = 'byte'): DataType {
+        return type.toLowerCase() as DataType;
     }
 
-    public static getEndianness(endian: Endianness): string {
-        return endian.length < 4 ? endian.toUpperCase() : ENDIAN_SUFFIX[endian.toUpperCase()];
+    public static getSignage(signed: Signedness): Signedness {
+        return (signed.length === 1 ? signed : signed.charAt(0)).toUpperCase() as Signedness;
     }
 
-    public get(type: DataType = 'byte', signed: Signedness = 'signed', endian: Endianness = 'be'): number {
+    public static getEndianness(endian: Endianness): Endianness {
+        return (endian.length < 4 ? endian : ENDIAN_SUFFIX[endian.toLowerCase()]).toUpperCase() as Endianness;
+    }
+
+    public static fromNodeBuffer(buffer: Buffer): ByteBuffer {
+        return new ByteBuffer(buffer);
+    }
+
+    public static toNodeBuffer(byteBuffer: ByteBuffer): Buffer {
+        return byteBuffer.toNodeBuffer();
+    }
+
+    public toNodeBuffer(): Buffer {
+        return Buffer.from(this);
+    }
+
+    public get(type: 'string' | 'STRING'): string;
+    public get(type: DataType, signed?: Signedness, endian?: Endianness): number;
+    public get(type: DataType = 'byte', signed: Signedness = 'signed', endian: Endianness = 'be'): number | string {
+        type = ByteBuffer.getType(type);
+        signed = ByteBuffer.getSignage(signed);
+        endian = ByteBuffer.getEndianness(endian);
+
         const readerIndex = this._readerIndex;
 
-        const typeString = type.toUpperCase();
-        const signedString = ByteBuffer.getSignage(signed);
-        const endianString = ByteBuffer.getEndianness(endian);
-
-        if(typeString === 'SMART') {
+        if(type === 'smart') {
             return this.getSmart(readerIndex, signed);
+        } else if(type === 'string') {
+            return this.getString();
         } else {
-            let size = BYTE_LENGTH[typeString];
-            let signedChar = signedString === 'S' ? '' : 'U';
-            let bitLength = BIT_LENGTH[typeString];
-            let suffix = typeString === 'BYTE' ? '' : endianString;
-            let smol = typeString === 'LONG' ? 'Big' : '';
+            const size = BYTE_LENGTH[type];
+            const signedChar = signed === 'S' ? '' : 'U';
+            const bitLength = BIT_LENGTH[type];
+            const suffix = type === 'byte' ? '' : endian;
+            const smol = type === 'long' ? 'Big' : '';
 
             this._readerIndex += size;
             const methodName = `read${signedChar}${smol}Int${bitLength}${suffix}`;
-            return this[methodName](readerIndex) as number;
+
+            try {
+                return this[methodName](readerIndex) as number;
+            } catch(error) {
+                logger.error(`Error reading ${methodName}:`, error);
+                return null;
+            }
         }
     }
 
-    public getString(terminatingChar: number = 0): string {
-        const bytes: number[] = [];
-        let b: number;
-
-        while((b = this.get('byte')) !== terminatingChar) {
-            bytes.push(b);
-        }
-
-        return Buffer.from(bytes).toString();
-    }
-
-    public put(value: number | bigint, type: DataType = 'byte', endian: Endianness = 'be'): ByteBuffer {
+    public put(value: string, type: 'string' | 'STRING'): ByteBuffer;
+    public put(value: number | bigint, type?: DataType, endian?: Endianness): ByteBuffer
+    public put(value: number | bigint | string, type: DataType = 'byte', endian: Endianness = 'be'): ByteBuffer {
         const writerIndex = this._writerIndex;
 
-        const typeString = type.toUpperCase();
-        const endianString = ByteBuffer.getEndianness(endian);
+        type = ByteBuffer.getType(type);
+        endian = ByteBuffer.getEndianness(endian);
 
-        if(typeString === 'SMART') {
-            this.putSmart(value as number);
+        if(type === 'smart') {
+            return this.putSmart(value as number);
+        } else if(type === 'string') {
+            if(typeof value === 'string') {
+                return this.putString(value);
+            }
         } else {
-            let maxSignedLength = MAX_SIGNED_LENGTHS[typeString];
-            let size = BYTE_LENGTH[typeString];
-            let signedChar = value > maxSignedLength ? 'U' : '';
-            let lenChars = BIT_LENGTH[typeString];
-            let suffix = typeString === 'BYTE' ? '' : endianString;
-            let smol = typeString === 'LONG' ? 'Big' : '';
+            const maxSignedLength = MAX_SIGNED_LENGTHS[type];
+            const size = BYTE_LENGTH[type];
+            const signedChar = value > maxSignedLength ? 'U' : '';
+            const lenChars = BIT_LENGTH[type];
+            const suffix = type === 'byte' ? '' : endian;
+            const smol = type === 'long' ? 'Big' : '';
 
             this._writerIndex += size;
             const methodName = `write${signedChar}${smol}Int${lenChars}${suffix}`;
-            this[methodName](value, writerIndex);
+
+            try {
+                return this[methodName](value, writerIndex);
+            } catch(error) {
+                logger.error(`Error writing ${methodName}:`, error);
+                return null;
+            }
         }
 
+        return null;
+    }
+
+    public at(index: number, signed: Signedness = 'signed'): number {
+        return ByteBuffer.getSignage(signed) === 'S' ? this.readInt8(index) : this.readUInt8(index);
+    }
+
+    public getSlice(position: number, length: number): ByteBuffer {
+        return new ByteBuffer(this.slice(position, position + length));
+    }
+
+    public putBytes(from: ByteBuffer | Buffer, fromStart?: number, fromEnd?: number): ByteBuffer {
+        from.copy(this, this.writerIndex, fromStart || 0, fromEnd || from.length);
+        this.writerIndex = (this.writerIndex + from.length);
         return this;
     }
 
-    public putString(value: string): ByteBuffer {
-        const encoder = new TextEncoder();
-        const bytes = encoder.encode(value);
-
-        for(const byte of bytes) {
-            this.put(byte);
-        }
-
-        this.put(0); // end of line
-        return this;
+    public getBytes(to: ByteBuffer | Buffer, length?: number): void {
+        this.copy(to, 0, this.readerIndex, this.readerIndex + length);
+        this.readerIndex += length;
     }
 
     public putBits(bitCount: number, value: number): ByteBuffer {
@@ -169,10 +205,6 @@ export class ByteBuffer extends Uint8Array {
         this.writerIndex = Math.floor((this.bitIndex + 7) / 8);
     }
 
-    public at(index: number, signed: Signedness = 'signed'): number {
-        return ByteBuffer.getSignage(signed) === 'S' ? this.readInt8(index) : this.readUInt8(index);
-    }
-
     public flipWriter(): ByteBuffer {
         const newBuffer = new ByteBuffer(this.writerIndex);
         this.copy(newBuffer, 0, 0, this.writerIndex);
@@ -185,34 +217,43 @@ export class ByteBuffer extends Uint8Array {
         return newBuffer;
     }
 
-    public getSlice(position: number, length: number): ByteBuffer {
-        return new ByteBuffer(this.slice(position, position + length));
-    }
-
-    public putBytes(from: ByteBuffer | Buffer, fromStart?: number, fromEnd?: number): ByteBuffer {
-        from.copy(this, this.writerIndex, fromStart || 0, fromEnd || from.length);
-        this.writerIndex = (this.writerIndex + from.length);
-        return this;
-    }
-
-    public getBytes(to: ByteBuffer | Buffer, length?: number): void {
-        this.copy(to, 0, this.readerIndex, this.readerIndex + length);
-        this.readerIndex += length;
-    }
-
     public readInt8: (offset: number) => number;
     public readUInt8: (offset: number) => number;
     public copy: (targetBuffer: Uint8Array, targetStart?: number, sourceStart?: number, sourceEnd?: number) => number;
 
-    private putSmart(value: number): void {
+    public getString(terminatingChar: number = 0): string {
+        const bytes: number[] = [];
+        let b: number;
+
+        while((b = this.get('byte')) !== terminatingChar) {
+            bytes.push(b);
+        }
+
+        return Buffer.from(bytes).toString();
+    }
+
+    public putString(value: string): ByteBuffer {
+        const encoder = new TextEncoder();
+        const bytes = encoder.encode(value);
+
+        for(const byte of bytes) {
+            this.put(byte);
+        }
+
+        this.put(0); // end of line
+        return this;
+    }
+
+    public putSmart(value: number): ByteBuffer {
         if(value >= 128) {
             this.put(value, 'short');
         } else {
             this.put(value, 'byte');
         }
+        return this;
     }
 
-    private getSmart(offset: number, signed: Signedness = 'SIGNED'): number {
+    public getSmart(offset: number, signed: Signedness = 'SIGNED'): number {
         const peek = this[offset];
 
         const signedString = ByteBuffer.getSignage(signed);
@@ -224,41 +265,41 @@ export class ByteBuffer extends Uint8Array {
         }
     }
 
-    private readUInt24BE(offset: number): number {
+    public readUInt24BE(offset: number): number {
         return ((this[offset] & 0xff) << 16) + ((this[offset + 1] & 0xff) << 8) + (this[offset + 2] & 0xff);
     }
 
-    private readInt24BE(offset: number): number {
+    public readInt24BE(offset: number): number {
         return ((this[offset]) << 16) + ((this[offset + 1]) << 8) + (this[offset + 2]);
     }
 
-    private readUInt24LE(offset: number): number {
+    public readUInt24LE(offset: number): number {
         return ((this[offset + 2] & 0xff) << 16) + ((this[offset + 1] & 0xff) << 8) + (this[offset] & 0xff);
     }
 
-    private readInt24LE(offset: number): number {
+    public readInt24LE(offset: number): number {
         return ((this[offset + 2]) << 16) + ((this[offset + 1]) << 8) + (this[offset]);
     }
 
-    private writeUInt24BE(value: number, offset: number): void {
+    public writeUInt24BE(value: number, offset: number): void {
         this[offset] = ((value & 0xff) >> 16);
         this[offset + 1] = ((value & 0xff) >> 8);
         this[offset + 2] = (value & 0xff);
     }
 
-    private writeInt24BE(value: number, offset: number): void {
+    public writeInt24BE(value: number, offset: number): void {
         this[offset] = (value >> 16);
         this[offset + 1] = (value >> 8);
         this[offset + 2] = (value);
     }
 
-    private writeUInt24LE(value: number, offset: number): void {
+    public writeUInt24LE(value: number, offset: number): void {
         this[offset + 2] = ((value & 0xff) >> 16);
         this[offset + 1] = ((value & 0xff) >> 8);
         this[offset] = (value & 0xff);
     }
 
-    private writeInt24LE(value: number, offset: number): void {
+    public writeInt24LE(value: number, offset: number): void {
         this[offset + 2] = (value >> 16);
         this[offset + 1] = (value >> 8);
         this[offset] = (value);
@@ -288,6 +329,13 @@ export class ByteBuffer extends Uint8Array {
         return this.length - this._writerIndex;
     }
 
+    public get bitIndex(): number {
+        return this._bitIndex;
+    }
+
+    public set bitIndex(value: number) {
+        this._bitIndex = value;
+    }
 }
 
 Object.setPrototypeOf(ByteBuffer.prototype, Buffer.prototype);

--- a/src/logger/logger.ts
+++ b/src/logger/logger.ts
@@ -42,7 +42,7 @@ export class RuneLogger {
     }
 
     private log(consoleType: string, ...args: any[]): void {
-        (this.pinoLogger[consoleType] as any)(...args);
+        args.forEach(arg => (this.pinoLogger[consoleType] as any)(arg));
     }
 
 }

--- a/src/net/connection-status.ts
+++ b/src/net/connection-status.ts
@@ -1,0 +1,5 @@
+export enum ConnectionStatus {
+    HANDSHAKE = 'handshake',
+    ACTIVE = 'active',
+    CLOSED = 'closed'
+}

--- a/src/net/index.ts
+++ b/src/net/index.ts
@@ -1,2 +1,3 @@
 export * from './server-config';
 export * from './socket-server';
+export * from './connection-status';

--- a/src/net/socket-server.ts
+++ b/src/net/socket-server.ts
@@ -70,7 +70,7 @@ export abstract class SocketServer<T = undefined> {
     }
 
     abstract initialHandshake(data: ByteBuffer): boolean;
-    abstract decodeMessage(data: ByteBuffer): void;
+    abstract decodeMessage(data: ByteBuffer): void | Promise<void>;
     abstract connectionDestroyed(): void;
 
     public closeConnection(): void {
@@ -96,6 +96,10 @@ export abstract class SocketServer<T = undefined> {
 
     public get connectionStatus(): ConnectionStatus | T {
         return this._connectionStatus;
+    }
+
+    public get connectionAlive(): boolean {
+        return this.socket?.writable && !this.socket.destroyed;
     }
 
 }


### PR DESCRIPTION
## Features
* Refactored core networking API to be more intuitive and simpler
  * All-new `SocketServer` class to handle RuneJS socket servers
  * Server configuration files can now be written in either **JSON** or the original **YAML** format
* Added `toNodeBuffer()` to `ByteBuffer`
* `ByteBuffer.put` and `ByteBuffer.get` now both support the `string` data type
* All private `ByteBuffer` methods have been made **public**
* Getter and setter created for `ByteBuffer.bitIndex`