### PR TITLE
Replace ESLint with Biome

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -1,9 +1,9 @@
 {
     "$schema": "https://biomejs.dev/schemas/1.9.4/schema.json",
     "vcs": {
-        "enabled": false,
+        "enabled": true,
         "clientKind": "git",
-        "useIgnoreFile": false
+        "useIgnoreFile": true
     },
     "files": {
         "ignoreUnknown": false,
@@ -20,7 +20,11 @@
     "linter": {
         "enabled": true,
         "rules": {
-            "recommended": true
+            "recommended": true,
+            "complexity": {
+                "recommended": true,
+                "noForEach": "off"
+            }
         }
     },
     "javascript": {

--- a/biome.json
+++ b/biome.json
@@ -1,0 +1,31 @@
+{
+    "$schema": "https://biomejs.dev/schemas/1.9.4/schema.json",
+    "vcs": {
+        "enabled": false,
+        "clientKind": "git",
+        "useIgnoreFile": false
+    },
+    "files": {
+        "ignoreUnknown": false,
+        "ignore": []
+    },
+    "formatter": {
+        "enabled": true,
+        "indentStyle": "space",
+        "indentWidth": 4
+    },
+    "organizeImports": {
+        "enabled": true
+    },
+    "linter": {
+        "enabled": true,
+        "rules": {
+            "recommended": true
+        }
+    },
+    "javascript": {
+        "formatter": {
+            "quoteStyle": "single"
+        }
+    }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@runejs/common",
-    "version": "2.0.2-beta.2",
+    "version": "2.0.2-beta.3",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "@runejs/common",
-            "version": "2.0.2-beta.2",
+            "version": "2.0.2-beta.3",
             "license": "GPL-3.0",
             "dependencies": {
                 "compressjs": "^1.0.3",
@@ -14,28 +14,24 @@
                 "pino": "^6.14.0",
                 "pino-pretty": "^4.8.0",
                 "sonic-boom": "^2.6.0",
-                "tslib": "^2.3.1"
+                "tslib": ">=2.8.1"
             },
             "devDependencies": {
-                "@runejs/eslint-config": "^1.1.0",
-                "@types/node": "^16.11.26",
+                "@types/node": "^22.10.7",
                 "@types/pino": "^6.3.12",
-                "@typescript-eslint/eslint-plugin": "^5.14.0",
-                "@typescript-eslint/parser": "^5.14.0",
                 "copyfiles": "^2.4.1",
-                "eslint": "^8.11.0",
                 "rimraf": "^3.0.2",
-                "ts-node-dev": "^1.1.8",
-                "typescript": "^4.5.5"
+                "ts-node": "^10.9.2",
+                "typescript": "^5.7.3"
             },
             "peerDependencies": {
-                "tslib": ">=2.3.0"
+                "tslib": ">=2.8.1"
             }
         },
         "../eslint-config": {
             "name": "@runejs/eslint-config",
             "version": "1.1.0",
-            "dev": true,
+            "extraneous": true,
             "license": "GPL-3.0",
             "devDependencies": {
                 "@typescript-eslint/eslint-plugin": "^5.14.0",
@@ -49,42 +45,17 @@
                 "eslint": ">=8"
             }
         },
-        "node_modules/@eslint/eslintrc": {
-            "version": "1.2.1",
-            "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-1.2.1.tgz",
-            "integrity": "sha512-bxvbYnBPN1Gibwyp6NrpnFzA3YtRL3BBAyEAFVIpNTm2Rn4Vy87GA5M4aSn3InRrlsbX5N0GW7XIx+U4SAEKdQ==",
+        "node_modules/@cspotcode/source-map-support": {
+            "version": "0.8.1",
+            "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
+            "integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
-                "ajv": "^6.12.4",
-                "debug": "^4.3.2",
-                "espree": "^9.3.1",
-                "globals": "^13.9.0",
-                "ignore": "^5.2.0",
-                "import-fresh": "^3.2.1",
-                "js-yaml": "^4.1.0",
-                "minimatch": "^3.0.4",
-                "strip-json-comments": "^3.1.1"
+                "@jridgewell/trace-mapping": "0.3.9"
             },
             "engines": {
-                "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-            }
-        },
-        "node_modules/@eslint/eslintrc/node_modules/argparse": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
-            "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-            "dev": true
-        },
-        "node_modules/@eslint/eslintrc/node_modules/js-yaml": {
-            "version": "4.1.0",
-            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
-            "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
-            "dev": true,
-            "dependencies": {
-                "argparse": "^2.0.1"
-            },
-            "bin": {
-                "js-yaml": "bin/js-yaml.js"
+                "node": ">=12"
             }
         },
         "node_modules/@hapi/bourne": {
@@ -92,76 +63,71 @@
             "resolved": "https://registry.npmjs.org/@hapi/bourne/-/bourne-2.0.0.tgz",
             "integrity": "sha512-WEezM1FWztfbzqIUbsDzFRVMxSoLy3HugVcux6KDDtTqzPsLE8NDRHfXvev66aH1i2oOKKar3/XDjbvh/OUBdg=="
         },
-        "node_modules/@humanwhocodes/config-array": {
-            "version": "0.9.5",
-            "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.9.5.tgz",
-            "integrity": "sha512-ObyMyWxZiCu/yTisA7uzx81s40xR2fD5Cg/2Kq7G02ajkNubJf6BopgDTmDyc3U7sXpNKM8cYOw7s7Tyr+DnCw==",
+        "node_modules/@jridgewell/resolve-uri": {
+            "version": "3.1.2",
+            "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+            "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
             "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=6.0.0"
+            }
+        },
+        "node_modules/@jridgewell/sourcemap-codec": {
+            "version": "1.5.0",
+            "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.0.tgz",
+            "integrity": "sha512-gv3ZRaISU3fjPAgNsriBRqGWQL6quFx04YMPW/zD8XMLsU32mhCCbfbO6KZFLjvYpCZ8zyDEgqsgf+PwPaM7GQ==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/@jridgewell/trace-mapping": {
+            "version": "0.3.9",
+            "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
+            "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
+            "dev": true,
+            "license": "MIT",
             "dependencies": {
-                "@humanwhocodes/object-schema": "^1.2.1",
-                "debug": "^4.1.1",
-                "minimatch": "^3.0.4"
-            },
-            "engines": {
-                "node": ">=10.10.0"
+                "@jridgewell/resolve-uri": "^3.0.3",
+                "@jridgewell/sourcemap-codec": "^1.4.10"
             }
         },
-        "node_modules/@humanwhocodes/object-schema": {
-            "version": "1.2.1",
-            "resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-1.2.1.tgz",
-            "integrity": "sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==",
-            "dev": true
-        },
-        "node_modules/@nodelib/fs.scandir": {
-            "version": "2.1.5",
-            "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
-            "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
+        "node_modules/@tsconfig/node10": {
+            "version": "1.0.11",
+            "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.11.tgz",
+            "integrity": "sha512-DcRjDCujK/kCk/cUe8Xz8ZSpm8mS3mNNpta+jGCA6USEDfktlNvm1+IuZ9eTcDbNk41BHwpHHeW+N1lKCz4zOw==",
             "dev": true,
-            "dependencies": {
-                "@nodelib/fs.stat": "2.0.5",
-                "run-parallel": "^1.1.9"
-            },
-            "engines": {
-                "node": ">= 8"
-            }
+            "license": "MIT"
         },
-        "node_modules/@nodelib/fs.stat": {
-            "version": "2.0.5",
-            "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
-            "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
+        "node_modules/@tsconfig/node12": {
+            "version": "1.0.11",
+            "resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.11.tgz",
+            "integrity": "sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==",
             "dev": true,
-            "engines": {
-                "node": ">= 8"
-            }
+            "license": "MIT"
         },
-        "node_modules/@nodelib/fs.walk": {
-            "version": "1.2.8",
-            "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
-            "integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
+        "node_modules/@tsconfig/node14": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.3.tgz",
+            "integrity": "sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==",
             "dev": true,
-            "dependencies": {
-                "@nodelib/fs.scandir": "2.1.5",
-                "fastq": "^1.6.0"
-            },
-            "engines": {
-                "node": ">= 8"
-            }
+            "license": "MIT"
         },
-        "node_modules/@runejs/eslint-config": {
-            "resolved": "../eslint-config",
-            "link": true
-        },
-        "node_modules/@types/json-schema": {
-            "version": "7.0.9",
-            "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.9.tgz",
-            "integrity": "sha512-qcUXuemtEu+E5wZSJHNxUXeCZhAfXKQ41D+duX+VYPde7xyEVZci+/oXKJL13tnRs9lR2pr4fod59GT6/X1/yQ==",
-            "dev": true
+        "node_modules/@tsconfig/node16": {
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.4.tgz",
+            "integrity": "sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/@types/node": {
-            "version": "16.11.26",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-16.11.26.tgz",
-            "integrity": "sha512-GZ7bu5A6+4DtG7q9GsoHXy3ALcgeIHP4NnL0Vv2wu0uUB/yQex26v0tf6/na1mm0+bS9Uw+0DFex7aaKr2qawQ==",
-            "dev": true
+            "version": "22.10.7",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-22.10.7.tgz",
+            "integrity": "sha512-V09KvXxFiutGp6B7XkpaDXlNadZxrzajcY50EuoLIpQ6WWYCSvf19lVIazzfIzQvhUN2HjX12spLojTnhuKlGg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "undici-types": "~6.20.0"
+            }
         },
         "node_modules/@types/pino": {
             "version": "6.3.12",
@@ -193,207 +159,12 @@
                 "@types/node": "*"
             }
         },
-        "node_modules/@types/strip-bom": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/@types/strip-bom/-/strip-bom-3.0.0.tgz",
-            "integrity": "sha1-FKjsOVbC6B7bdSB5CuzyHCkK69I=",
-            "dev": true
-        },
-        "node_modules/@types/strip-json-comments": {
-            "version": "0.0.30",
-            "resolved": "https://registry.npmjs.org/@types/strip-json-comments/-/strip-json-comments-0.0.30.tgz",
-            "integrity": "sha512-7NQmHra/JILCd1QqpSzl8+mJRc8ZHz3uDm8YV1Ks9IhK0epEiTw8aIErbvH9PI+6XbqhyIQy3462nEsn7UVzjQ==",
-            "dev": true
-        },
-        "node_modules/@typescript-eslint/eslint-plugin": {
-            "version": "5.14.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.14.0.tgz",
-            "integrity": "sha512-ir0wYI4FfFUDfLcuwKzIH7sMVA+db7WYen47iRSaCGl+HMAZI9fpBwfDo45ZALD3A45ZGyHWDNLhbg8tZrMX4w==",
-            "dev": true,
-            "dependencies": {
-                "@typescript-eslint/scope-manager": "5.14.0",
-                "@typescript-eslint/type-utils": "5.14.0",
-                "@typescript-eslint/utils": "5.14.0",
-                "debug": "^4.3.2",
-                "functional-red-black-tree": "^1.0.1",
-                "ignore": "^5.1.8",
-                "regexpp": "^3.2.0",
-                "semver": "^7.3.5",
-                "tsutils": "^3.21.0"
-            },
-            "engines": {
-                "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/typescript-eslint"
-            },
-            "peerDependencies": {
-                "@typescript-eslint/parser": "^5.0.0",
-                "eslint": "^6.0.0 || ^7.0.0 || ^8.0.0"
-            },
-            "peerDependenciesMeta": {
-                "typescript": {
-                    "optional": true
-                }
-            }
-        },
-        "node_modules/@typescript-eslint/parser": {
-            "version": "5.14.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.14.0.tgz",
-            "integrity": "sha512-aHJN8/FuIy1Zvqk4U/gcO/fxeMKyoSv/rS46UXMXOJKVsLQ+iYPuXNbpbH7cBLcpSbmyyFbwrniLx5+kutu1pw==",
-            "dev": true,
-            "dependencies": {
-                "@typescript-eslint/scope-manager": "5.14.0",
-                "@typescript-eslint/types": "5.14.0",
-                "@typescript-eslint/typescript-estree": "5.14.0",
-                "debug": "^4.3.2"
-            },
-            "engines": {
-                "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/typescript-eslint"
-            },
-            "peerDependencies": {
-                "eslint": "^6.0.0 || ^7.0.0 || ^8.0.0"
-            },
-            "peerDependenciesMeta": {
-                "typescript": {
-                    "optional": true
-                }
-            }
-        },
-        "node_modules/@typescript-eslint/scope-manager": {
-            "version": "5.14.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.14.0.tgz",
-            "integrity": "sha512-LazdcMlGnv+xUc5R4qIlqH0OWARyl2kaP8pVCS39qSL3Pd1F7mI10DbdXeARcE62sVQE4fHNvEqMWsypWO+yEw==",
-            "dev": true,
-            "dependencies": {
-                "@typescript-eslint/types": "5.14.0",
-                "@typescript-eslint/visitor-keys": "5.14.0"
-            },
-            "engines": {
-                "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/typescript-eslint"
-            }
-        },
-        "node_modules/@typescript-eslint/type-utils": {
-            "version": "5.14.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.14.0.tgz",
-            "integrity": "sha512-d4PTJxsqaUpv8iERTDSQBKUCV7Q5yyXjqXUl3XF7Sd9ogNLuKLkxz82qxokqQ4jXdTPZudWpmNtr/JjbbvUixw==",
-            "dev": true,
-            "dependencies": {
-                "@typescript-eslint/utils": "5.14.0",
-                "debug": "^4.3.2",
-                "tsutils": "^3.21.0"
-            },
-            "engines": {
-                "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/typescript-eslint"
-            },
-            "peerDependencies": {
-                "eslint": "*"
-            },
-            "peerDependenciesMeta": {
-                "typescript": {
-                    "optional": true
-                }
-            }
-        },
-        "node_modules/@typescript-eslint/types": {
-            "version": "5.14.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.14.0.tgz",
-            "integrity": "sha512-BR6Y9eE9360LNnW3eEUqAg6HxS9Q35kSIs4rp4vNHRdfg0s+/PgHgskvu5DFTM7G5VKAVjuyaN476LCPrdA7Mw==",
-            "dev": true,
-            "engines": {
-                "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/typescript-eslint"
-            }
-        },
-        "node_modules/@typescript-eslint/typescript-estree": {
-            "version": "5.14.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.14.0.tgz",
-            "integrity": "sha512-QGnxvROrCVtLQ1724GLTHBTR0lZVu13izOp9njRvMkCBgWX26PKvmMP8k82nmXBRD3DQcFFq2oj3cKDwr0FaUA==",
-            "dev": true,
-            "dependencies": {
-                "@typescript-eslint/types": "5.14.0",
-                "@typescript-eslint/visitor-keys": "5.14.0",
-                "debug": "^4.3.2",
-                "globby": "^11.0.4",
-                "is-glob": "^4.0.3",
-                "semver": "^7.3.5",
-                "tsutils": "^3.21.0"
-            },
-            "engines": {
-                "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/typescript-eslint"
-            },
-            "peerDependenciesMeta": {
-                "typescript": {
-                    "optional": true
-                }
-            }
-        },
-        "node_modules/@typescript-eslint/utils": {
-            "version": "5.14.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.14.0.tgz",
-            "integrity": "sha512-EHwlII5mvUA0UsKYnVzySb/5EE/t03duUTweVy8Zqt3UQXBrpEVY144OTceFKaOe4xQXZJrkptCf7PjEBeGK4w==",
-            "dev": true,
-            "dependencies": {
-                "@types/json-schema": "^7.0.9",
-                "@typescript-eslint/scope-manager": "5.14.0",
-                "@typescript-eslint/types": "5.14.0",
-                "@typescript-eslint/typescript-estree": "5.14.0",
-                "eslint-scope": "^5.1.1",
-                "eslint-utils": "^3.0.0"
-            },
-            "engines": {
-                "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/typescript-eslint"
-            },
-            "peerDependencies": {
-                "eslint": "^6.0.0 || ^7.0.0 || ^8.0.0"
-            }
-        },
-        "node_modules/@typescript-eslint/visitor-keys": {
-            "version": "5.14.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.14.0.tgz",
-            "integrity": "sha512-yL0XxfzR94UEkjBqyymMLgCBdojzEuy/eim7N9/RIcTNxpJudAcqsU8eRyfzBbcEzGoPWfdM3AGak3cN08WOIw==",
-            "dev": true,
-            "dependencies": {
-                "@typescript-eslint/types": "5.14.0",
-                "eslint-visitor-keys": "^3.0.0"
-            },
-            "engines": {
-                "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/typescript-eslint"
-            }
-        },
         "node_modules/acorn": {
-            "version": "8.7.0",
-            "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.7.0.tgz",
-            "integrity": "sha512-V/LGr1APy+PXIwKebEWrkZPwoeoF+w1jiOBUmuxuiUIaOHtob8Qc9BTrYo7VuI5fR8tqsy+buA2WFooR5olqvQ==",
+            "version": "8.14.0",
+            "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.14.0.tgz",
+            "integrity": "sha512-cl669nCJTZBsL97OF4kUQm5g5hC2uihk0NxY3WENAC0TYdILVkAyHymAntgxGkl7K+t0cXIrH5siy5S4XkFycA==",
             "dev": true,
+            "license": "MIT",
             "bin": {
                 "acorn": "bin/acorn"
             },
@@ -401,29 +172,17 @@
                 "node": ">=0.4.0"
             }
         },
-        "node_modules/acorn-jsx": {
-            "version": "5.3.2",
-            "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
-            "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
+        "node_modules/acorn-walk": {
+            "version": "8.3.4",
+            "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.4.tgz",
+            "integrity": "sha512-ueEepnujpqee2o5aIYnvHU6C0A42MNdsIDeqy5BydrkuC5R1ZuUFnm27EeFJGoEHJQgn3uleRvmTXaJgfXbt4g==",
             "dev": true,
-            "peerDependencies": {
-                "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
-            }
-        },
-        "node_modules/ajv": {
-            "version": "6.12.6",
-            "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
-            "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
-            "dev": true,
+            "license": "MIT",
             "dependencies": {
-                "fast-deep-equal": "^3.1.1",
-                "fast-json-stable-stringify": "^2.0.0",
-                "json-schema-traverse": "^0.4.1",
-                "uri-js": "^4.2.2"
+                "acorn": "^8.11.0"
             },
-            "funding": {
-                "type": "github",
-                "url": "https://github.com/sponsors/epoberezkin"
+            "engines": {
+                "node": ">=0.4.0"
             }
         },
         "node_modules/amdefine": {
@@ -455,19 +214,6 @@
             },
             "funding": {
                 "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-            }
-        },
-        "node_modules/anymatch": {
-            "version": "3.1.2",
-            "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.2.tgz",
-            "integrity": "sha512-P43ePfOAIupkguHUycrc4qJ9kz8ZiuOUijaETwX7THt0Y/GNK7v0aa8rY816xWjZ7rJdA5XdMcpVFTKMq+RvWg==",
-            "dev": true,
-            "dependencies": {
-                "normalize-path": "^3.0.0",
-                "picomatch": "^2.0.4"
-            },
-            "engines": {
-                "node": ">= 8"
             }
         },
         "node_modules/arg": {
@@ -554,15 +300,6 @@
                 "node": ">=4"
             }
         },
-        "node_modules/array-union": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
-            "integrity": "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==",
-            "dev": true,
-            "engines": {
-                "node": ">=8"
-            }
-        },
         "node_modules/atomic-sleep": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/atomic-sleep/-/atomic-sleep-1.0.0.tgz",
@@ -577,15 +314,6 @@
             "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
             "dev": true
         },
-        "node_modules/binary-extensions": {
-            "version": "2.2.0",
-            "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.2.0.tgz",
-            "integrity": "sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==",
-            "dev": true,
-            "engines": {
-                "node": ">=8"
-            }
-        },
         "node_modules/brace-expansion": {
             "version": "1.1.11",
             "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
@@ -594,33 +322,6 @@
             "dependencies": {
                 "balanced-match": "^1.0.0",
                 "concat-map": "0.0.1"
-            }
-        },
-        "node_modules/braces": {
-            "version": "3.0.2",
-            "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
-            "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
-            "dev": true,
-            "dependencies": {
-                "fill-range": "^7.0.1"
-            },
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "node_modules/buffer-from": {
-            "version": "1.1.2",
-            "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
-            "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
-            "dev": true
-        },
-        "node_modules/callsites": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
-            "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
-            "dev": true,
-            "engines": {
-                "node": ">=6"
             }
         },
         "node_modules/camelcase": {
@@ -644,27 +345,6 @@
             },
             "funding": {
                 "url": "https://github.com/chalk/chalk?sponsor=1"
-            }
-        },
-        "node_modules/chokidar": {
-            "version": "3.5.2",
-            "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.5.2.tgz",
-            "integrity": "sha512-ekGhOnNVPgT77r4K/U3GDhu+FQ2S8TnK/s2KbIGXi0SZWuwkZ2QNyfWdZW+TVfn84DpEP7rLeCt2UI6bJ8GwbQ==",
-            "dev": true,
-            "dependencies": {
-                "anymatch": "~3.1.2",
-                "braces": "~3.0.2",
-                "glob-parent": "~5.1.2",
-                "is-binary-path": "~2.1.0",
-                "is-glob": "~4.0.1",
-                "normalize-path": "~3.0.0",
-                "readdirp": "~3.6.0"
-            },
-            "engines": {
-                "node": ">= 8.10.0"
-            },
-            "optionalDependencies": {
-                "fsevents": "~2.3.2"
             }
         },
         "node_modules/cliui": {
@@ -754,20 +434,6 @@
             "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
             "dev": true
         },
-        "node_modules/cross-spawn": {
-            "version": "7.0.3",
-            "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
-            "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
-            "dev": true,
-            "dependencies": {
-                "path-key": "^3.1.0",
-                "shebang-command": "^2.0.0",
-                "which": "^2.0.1"
-            },
-            "engines": {
-                "node": ">= 8"
-            }
-        },
         "node_modules/dateformat": {
             "version": "4.5.1",
             "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-4.5.1.tgz",
@@ -776,29 +442,6 @@
                 "node": "*"
             }
         },
-        "node_modules/debug": {
-            "version": "4.3.2",
-            "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.2.tgz",
-            "integrity": "sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==",
-            "dev": true,
-            "dependencies": {
-                "ms": "2.1.2"
-            },
-            "engines": {
-                "node": ">=6.0"
-            },
-            "peerDependenciesMeta": {
-                "supports-color": {
-                    "optional": true
-                }
-            }
-        },
-        "node_modules/deep-is": {
-            "version": "0.1.3",
-            "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
-            "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=",
-            "dev": true
-        },
         "node_modules/diff": {
             "version": "4.0.2",
             "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
@@ -806,39 +449,6 @@
             "dev": true,
             "engines": {
                 "node": ">=0.3.1"
-            }
-        },
-        "node_modules/dir-glob": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-3.0.1.tgz",
-            "integrity": "sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==",
-            "dev": true,
-            "dependencies": {
-                "path-type": "^4.0.0"
-            },
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "node_modules/doctrine": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-3.0.0.tgz",
-            "integrity": "sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==",
-            "dev": true,
-            "dependencies": {
-                "esutils": "^2.0.2"
-            },
-            "engines": {
-                "node": ">=6.0.0"
-            }
-        },
-        "node_modules/dynamic-dedupe": {
-            "version": "0.3.0",
-            "resolved": "https://registry.npmjs.org/dynamic-dedupe/-/dynamic-dedupe-0.3.0.tgz",
-            "integrity": "sha1-BuRMIj9eTpTXjvnbI6ZRXOL5YqE=",
-            "dev": true,
-            "dependencies": {
-                "xtend": "^4.0.0"
             }
         },
         "node_modules/emoji-regex": {
@@ -872,185 +482,6 @@
                 "node": ">=0.8.0"
             }
         },
-        "node_modules/eslint": {
-            "version": "8.11.0",
-            "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.11.0.tgz",
-            "integrity": "sha512-/KRpd9mIRg2raGxHRGwW9ZywYNAClZrHjdueHcrVDuO3a6bj83eoTirCCk0M0yPwOjWYKHwRVRid+xK4F/GHgA==",
-            "dev": true,
-            "dependencies": {
-                "@eslint/eslintrc": "^1.2.1",
-                "@humanwhocodes/config-array": "^0.9.2",
-                "ajv": "^6.10.0",
-                "chalk": "^4.0.0",
-                "cross-spawn": "^7.0.2",
-                "debug": "^4.3.2",
-                "doctrine": "^3.0.0",
-                "escape-string-regexp": "^4.0.0",
-                "eslint-scope": "^7.1.1",
-                "eslint-utils": "^3.0.0",
-                "eslint-visitor-keys": "^3.3.0",
-                "espree": "^9.3.1",
-                "esquery": "^1.4.0",
-                "esutils": "^2.0.2",
-                "fast-deep-equal": "^3.1.3",
-                "file-entry-cache": "^6.0.1",
-                "functional-red-black-tree": "^1.0.1",
-                "glob-parent": "^6.0.1",
-                "globals": "^13.6.0",
-                "ignore": "^5.2.0",
-                "import-fresh": "^3.0.0",
-                "imurmurhash": "^0.1.4",
-                "is-glob": "^4.0.0",
-                "js-yaml": "^4.1.0",
-                "json-stable-stringify-without-jsonify": "^1.0.1",
-                "levn": "^0.4.1",
-                "lodash.merge": "^4.6.2",
-                "minimatch": "^3.0.4",
-                "natural-compare": "^1.4.0",
-                "optionator": "^0.9.1",
-                "regexpp": "^3.2.0",
-                "strip-ansi": "^6.0.1",
-                "strip-json-comments": "^3.1.0",
-                "text-table": "^0.2.0",
-                "v8-compile-cache": "^2.0.3"
-            },
-            "bin": {
-                "eslint": "bin/eslint.js"
-            },
-            "engines": {
-                "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-            },
-            "funding": {
-                "url": "https://opencollective.com/eslint"
-            }
-        },
-        "node_modules/eslint-scope": {
-            "version": "5.1.1",
-            "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.1.1.tgz",
-            "integrity": "sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==",
-            "dev": true,
-            "dependencies": {
-                "esrecurse": "^4.3.0",
-                "estraverse": "^4.1.1"
-            },
-            "engines": {
-                "node": ">=8.0.0"
-            }
-        },
-        "node_modules/eslint-utils": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-3.0.0.tgz",
-            "integrity": "sha512-uuQC43IGctw68pJA1RgbQS8/NP7rch6Cwd4j3ZBtgo4/8Flj4eGE7ZYSZRN3iq5pVUv6GPdW5Z1RFleo84uLDA==",
-            "dev": true,
-            "dependencies": {
-                "eslint-visitor-keys": "^2.0.0"
-            },
-            "engines": {
-                "node": "^10.0.0 || ^12.0.0 || >= 14.0.0"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/mysticatea"
-            },
-            "peerDependencies": {
-                "eslint": ">=5"
-            }
-        },
-        "node_modules/eslint-utils/node_modules/eslint-visitor-keys": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-2.1.0.tgz",
-            "integrity": "sha512-0rSmRBzXgDzIsD6mGdJgevzgezI534Cer5L/vyMX0kHzT/jiB43jRhd9YUlMGYLQy2zprNmoT8qasCGtY+QaKw==",
-            "dev": true,
-            "engines": {
-                "node": ">=10"
-            }
-        },
-        "node_modules/eslint-visitor-keys": {
-            "version": "3.3.0",
-            "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.3.0.tgz",
-            "integrity": "sha512-mQ+suqKJVyeuwGYHAdjMFqjCyfl8+Ldnxuyp3ldiMBFKkvytrXUZWaiPCEav8qDHKty44bD+qV1IP4T+w+xXRA==",
-            "dev": true,
-            "engines": {
-                "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-            }
-        },
-        "node_modules/eslint/node_modules/argparse": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
-            "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-            "dev": true
-        },
-        "node_modules/eslint/node_modules/escape-string-regexp": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
-            "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
-            "dev": true,
-            "engines": {
-                "node": ">=10"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/eslint/node_modules/eslint-scope": {
-            "version": "7.1.1",
-            "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-7.1.1.tgz",
-            "integrity": "sha512-QKQM/UXpIiHcLqJ5AOyIW7XZmzjkzQXYE54n1++wb0u9V/abW3l9uQnxX8Z5Xd18xyKIMTUAyQ0k1e8pz6LUrw==",
-            "dev": true,
-            "dependencies": {
-                "esrecurse": "^4.3.0",
-                "estraverse": "^5.2.0"
-            },
-            "engines": {
-                "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-            }
-        },
-        "node_modules/eslint/node_modules/estraverse": {
-            "version": "5.3.0",
-            "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
-            "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
-            "dev": true,
-            "engines": {
-                "node": ">=4.0"
-            }
-        },
-        "node_modules/eslint/node_modules/glob-parent": {
-            "version": "6.0.2",
-            "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
-            "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
-            "dev": true,
-            "dependencies": {
-                "is-glob": "^4.0.3"
-            },
-            "engines": {
-                "node": ">=10.13.0"
-            }
-        },
-        "node_modules/eslint/node_modules/js-yaml": {
-            "version": "4.1.0",
-            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
-            "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
-            "dev": true,
-            "dependencies": {
-                "argparse": "^2.0.1"
-            },
-            "bin": {
-                "js-yaml": "bin/js-yaml.js"
-            }
-        },
-        "node_modules/espree": {
-            "version": "9.3.1",
-            "resolved": "https://registry.npmjs.org/espree/-/espree-9.3.1.tgz",
-            "integrity": "sha512-bvdyLmJMfwkV3NCRl5ZhJf22zBFo1y8bYh3VYb+bfzqNB4Je68P2sSuXyuFquzWLebHpNd2/d5uv7yoP9ISnGQ==",
-            "dev": true,
-            "dependencies": {
-                "acorn": "^8.7.0",
-                "acorn-jsx": "^5.3.1",
-                "eslint-visitor-keys": "^3.3.0"
-            },
-            "engines": {
-                "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-            }
-        },
         "node_modules/esprima": {
             "version": "4.0.1",
             "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
@@ -1062,100 +493,6 @@
             "engines": {
                 "node": ">=4"
             }
-        },
-        "node_modules/esquery": {
-            "version": "1.4.0",
-            "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.4.0.tgz",
-            "integrity": "sha512-cCDispWt5vHHtwMY2YrAQ4ibFkAL8RbH5YGBnZBc90MolvvfkkQcJro/aZiAQUlQ3qgrYS6D6v8Gc5G5CQsc9w==",
-            "dev": true,
-            "dependencies": {
-                "estraverse": "^5.1.0"
-            },
-            "engines": {
-                "node": ">=0.10"
-            }
-        },
-        "node_modules/esquery/node_modules/estraverse": {
-            "version": "5.2.0",
-            "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.2.0.tgz",
-            "integrity": "sha512-BxbNGGNm0RyRYvUdHpIwv9IWzeM9XClbOxwoATuFdOE7ZE6wHL+HQ5T8hoPM+zHvmKzzsEqhgy0GrQ5X13afiQ==",
-            "dev": true,
-            "engines": {
-                "node": ">=4.0"
-            }
-        },
-        "node_modules/esrecurse": {
-            "version": "4.3.0",
-            "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
-            "integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
-            "dev": true,
-            "dependencies": {
-                "estraverse": "^5.2.0"
-            },
-            "engines": {
-                "node": ">=4.0"
-            }
-        },
-        "node_modules/esrecurse/node_modules/estraverse": {
-            "version": "5.3.0",
-            "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
-            "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
-            "dev": true,
-            "engines": {
-                "node": ">=4.0"
-            }
-        },
-        "node_modules/estraverse": {
-            "version": "4.3.0",
-            "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz",
-            "integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
-            "dev": true,
-            "engines": {
-                "node": ">=4.0"
-            }
-        },
-        "node_modules/esutils": {
-            "version": "2.0.3",
-            "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
-            "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
-            "dev": true,
-            "engines": {
-                "node": ">=0.10.0"
-            }
-        },
-        "node_modules/fast-deep-equal": {
-            "version": "3.1.3",
-            "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
-            "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
-            "dev": true
-        },
-        "node_modules/fast-glob": {
-            "version": "3.2.11",
-            "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.11.tgz",
-            "integrity": "sha512-xrO3+1bxSo3ZVHAnqzyuewYT6aMFHRAd4Kcs92MAonjwQZLsK9d0SF1IyQ3k5PoirxTW0Oe/RqFgMQ6TcNE5Ew==",
-            "dev": true,
-            "dependencies": {
-                "@nodelib/fs.stat": "^2.0.2",
-                "@nodelib/fs.walk": "^1.2.3",
-                "glob-parent": "^5.1.2",
-                "merge2": "^1.3.0",
-                "micromatch": "^4.0.4"
-            },
-            "engines": {
-                "node": ">=8.6.0"
-            }
-        },
-        "node_modules/fast-json-stable-stringify": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
-            "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
-            "dev": true
-        },
-        "node_modules/fast-levenshtein": {
-            "version": "2.0.6",
-            "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
-            "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
-            "dev": true
         },
         "node_modules/fast-redact": {
             "version": "3.0.1",
@@ -1170,93 +507,15 @@
             "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.0.8.tgz",
             "integrity": "sha512-lXatBjf3WPjmWD6DpIZxkeSsCOwqI0maYMpgDlx8g4U2qi4lbjA9oH/HD2a87G+KfsUmo5WbJFmqBZlPxtptag=="
         },
-        "node_modules/fastq": {
-            "version": "1.13.0",
-            "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.13.0.tgz",
-            "integrity": "sha512-YpkpUnK8od0o1hmeSc7UUs/eB/vIPWJYjKck2QKIzAf71Vm1AAQ3EbuZB3g2JIy+pg+ERD0vqI79KyZiB2e2Nw==",
-            "dev": true,
-            "dependencies": {
-                "reusify": "^1.0.4"
-            }
-        },
-        "node_modules/file-entry-cache": {
-            "version": "6.0.1",
-            "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-6.0.1.tgz",
-            "integrity": "sha512-7Gps/XWymbLk2QLYK4NzpMOrYjMhdIxXuIvy2QBsLE6ljuodKvdkWs/cpyJJ3CVIVpH0Oi1Hvg1ovbMzLdFBBg==",
-            "dev": true,
-            "dependencies": {
-                "flat-cache": "^3.0.4"
-            },
-            "engines": {
-                "node": "^10.12.0 || >=12.0.0"
-            }
-        },
-        "node_modules/fill-range": {
-            "version": "7.0.1",
-            "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
-            "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
-            "dev": true,
-            "dependencies": {
-                "to-regex-range": "^5.0.1"
-            },
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "node_modules/flat-cache": {
-            "version": "3.0.4",
-            "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-3.0.4.tgz",
-            "integrity": "sha512-dm9s5Pw7Jc0GvMYbshN6zchCA9RgQlzzEZX3vylR9IqFfS8XciblUXOKfW6SiuJ0e13eDYZoZV5wdrev7P3Nwg==",
-            "dev": true,
-            "dependencies": {
-                "flatted": "^3.1.0",
-                "rimraf": "^3.0.2"
-            },
-            "engines": {
-                "node": "^10.12.0 || >=12.0.0"
-            }
-        },
         "node_modules/flatstr": {
             "version": "1.0.12",
             "resolved": "https://registry.npmjs.org/flatstr/-/flatstr-1.0.12.tgz",
             "integrity": "sha512-4zPxDyhCyiN2wIAtSLI6gc82/EjqZc1onI4Mz/l0pWrAlsSfYH/2ZIcU+e3oA2wDwbzIWNKwa23F8rh6+DRWkw=="
         },
-        "node_modules/flatted": {
-            "version": "3.2.2",
-            "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.2.2.tgz",
-            "integrity": "sha512-JaTY/wtrcSyvXJl4IMFHPKyFur1sE9AUqc0QnhOaJ0CxHtAoIV8pYDzeEfAaNEtGkOfq4gr3LBFmdXW5mOQFnA==",
-            "dev": true
-        },
         "node_modules/fs.realpath": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
             "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
-            "dev": true
-        },
-        "node_modules/fsevents": {
-            "version": "2.3.2",
-            "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
-            "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
-            "dev": true,
-            "hasInstallScript": true,
-            "optional": true,
-            "os": [
-                "darwin"
-            ],
-            "engines": {
-                "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
-            }
-        },
-        "node_modules/function-bind": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
-            "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
-            "dev": true
-        },
-        "node_modules/functional-red-black-tree": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
-            "integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=",
             "dev": true
         },
         "node_modules/get-caller-file": {
@@ -1288,69 +547,10 @@
                 "url": "https://github.com/sponsors/isaacs"
             }
         },
-        "node_modules/glob-parent": {
-            "version": "5.1.2",
-            "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
-            "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
-            "dev": true,
-            "dependencies": {
-                "is-glob": "^4.0.1"
-            },
-            "engines": {
-                "node": ">= 6"
-            }
-        },
-        "node_modules/globals": {
-            "version": "13.12.1",
-            "resolved": "https://registry.npmjs.org/globals/-/globals-13.12.1.tgz",
-            "integrity": "sha512-317dFlgY2pdJZ9rspXDks7073GpDmXdfbM3vYYp0HAMKGDh1FfWPleI2ljVNLQX5M5lXcAslTcPTrOrMEFOjyw==",
-            "dev": true,
-            "dependencies": {
-                "type-fest": "^0.20.2"
-            },
-            "engines": {
-                "node": ">=8"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/globby": {
-            "version": "11.1.0",
-            "resolved": "https://registry.npmjs.org/globby/-/globby-11.1.0.tgz",
-            "integrity": "sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==",
-            "dev": true,
-            "dependencies": {
-                "array-union": "^2.1.0",
-                "dir-glob": "^3.0.1",
-                "fast-glob": "^3.2.9",
-                "ignore": "^5.2.0",
-                "merge2": "^1.4.1",
-                "slash": "^3.0.0"
-            },
-            "engines": {
-                "node": ">=10"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
         "node_modules/graceful-readlink": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz",
             "integrity": "sha1-TK+tdrxi8C+gObL5Tpo906ORpyU="
-        },
-        "node_modules/has": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
-            "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
-            "dev": true,
-            "dependencies": {
-                "function-bind": "^1.1.1"
-            },
-            "engines": {
-                "node": ">= 0.4.0"
-            }
         },
         "node_modules/has-flag": {
             "version": "4.0.0",
@@ -1358,40 +558,6 @@
             "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
             "engines": {
                 "node": ">=8"
-            }
-        },
-        "node_modules/ignore": {
-            "version": "5.2.0",
-            "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.2.0.tgz",
-            "integrity": "sha512-CmxgYGiEPCLhfLnpPp1MoRmifwEIOgjcHXxOBjv7mY96c+eWScsOP9c112ZyLdWHi0FxHjI+4uVhKYp/gcdRmQ==",
-            "dev": true,
-            "engines": {
-                "node": ">= 4"
-            }
-        },
-        "node_modules/import-fresh": {
-            "version": "3.3.0",
-            "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.0.tgz",
-            "integrity": "sha512-veYYhQa+D1QBKznvhUHxb8faxlrwUnxseDAbAp457E0wLNio2bOSKnjYDhMj+YiAq61xrMGhQk9iXVk5FzgQMw==",
-            "dev": true,
-            "dependencies": {
-                "parent-module": "^1.0.0",
-                "resolve-from": "^4.0.0"
-            },
-            "engines": {
-                "node": ">=6"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/imurmurhash": {
-            "version": "0.1.4",
-            "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
-            "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
-            "dev": true,
-            "engines": {
-                "node": ">=0.8.19"
             }
         },
         "node_modules/inflight": {
@@ -1409,39 +575,6 @@
             "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
             "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
         },
-        "node_modules/is-binary-path": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
-            "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
-            "dev": true,
-            "dependencies": {
-                "binary-extensions": "^2.0.0"
-            },
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "node_modules/is-core-module": {
-            "version": "2.8.0",
-            "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.8.0.tgz",
-            "integrity": "sha512-vd15qHsaqrRL7dtH6QNuy0ndJmRDrS9HAM1CAiSifNUFv4x1a0CCVsj18hJ1mShxIG6T2i1sO78MkP56r0nYRw==",
-            "dev": true,
-            "dependencies": {
-                "has": "^1.0.3"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
-        "node_modules/is-extglob": {
-            "version": "2.1.1",
-            "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
-            "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
-            "dev": true,
-            "engines": {
-                "node": ">=0.10.0"
-            }
-        },
         "node_modules/is-fullwidth-code-point": {
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
@@ -1451,37 +584,10 @@
                 "node": ">=8"
             }
         },
-        "node_modules/is-glob": {
-            "version": "4.0.3",
-            "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
-            "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
-            "dev": true,
-            "dependencies": {
-                "is-extglob": "^2.1.1"
-            },
-            "engines": {
-                "node": ">=0.10.0"
-            }
-        },
-        "node_modules/is-number": {
-            "version": "7.0.0",
-            "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
-            "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
-            "dev": true,
-            "engines": {
-                "node": ">=0.12.0"
-            }
-        },
         "node_modules/isarray": {
             "version": "0.0.1",
             "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
             "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
-            "dev": true
-        },
-        "node_modules/isexe": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-            "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
             "dev": true
         },
         "node_modules/jmespath": {
@@ -1512,18 +618,6 @@
                 "js-yaml": "bin/js-yaml.js"
             }
         },
-        "node_modules/json-schema-traverse": {
-            "version": "0.4.1",
-            "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-            "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
-            "dev": true
-        },
-        "node_modules/json-stable-stringify-without-jsonify": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
-            "integrity": "sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=",
-            "dev": true
-        },
         "node_modules/leven": {
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/leven/-/leven-2.1.0.tgz",
@@ -1532,64 +626,11 @@
                 "node": ">=0.10.0"
             }
         },
-        "node_modules/levn": {
-            "version": "0.4.1",
-            "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
-            "integrity": "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==",
-            "dev": true,
-            "dependencies": {
-                "prelude-ls": "^1.2.1",
-                "type-check": "~0.4.0"
-            },
-            "engines": {
-                "node": ">= 0.8.0"
-            }
-        },
-        "node_modules/lodash.merge": {
-            "version": "4.6.2",
-            "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
-            "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
-            "dev": true
-        },
-        "node_modules/lru-cache": {
-            "version": "6.0.0",
-            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-            "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-            "dev": true,
-            "dependencies": {
-                "yallist": "^4.0.0"
-            },
-            "engines": {
-                "node": ">=10"
-            }
-        },
         "node_modules/make-error": {
             "version": "1.3.6",
             "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
             "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
             "dev": true
-        },
-        "node_modules/merge2": {
-            "version": "1.4.1",
-            "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
-            "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
-            "dev": true,
-            "engines": {
-                "node": ">= 8"
-            }
-        },
-        "node_modules/micromatch": {
-            "version": "4.0.4",
-            "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.4.tgz",
-            "integrity": "sha512-pRmzw/XUcwXGpD9aI9q/0XOwLNygjETJ8y0ao0wdqprrzDa4YnxLcz7fQRZr8voh8V10kGhABbNcHVk5wHgWwg==",
-            "dev": true,
-            "dependencies": {
-                "braces": "^3.0.1",
-                "picomatch": "^2.2.3"
-            },
-            "engines": {
-                "node": ">=8.6"
-            }
         },
         "node_modules/minimatch": {
             "version": "3.0.4",
@@ -1602,12 +643,6 @@
             "engines": {
                 "node": "*"
             }
-        },
-        "node_modules/minimist": {
-            "version": "1.2.5",
-            "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-            "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
-            "dev": true
         },
         "node_modules/mkdirp": {
             "version": "1.0.4",
@@ -1628,18 +663,6 @@
             "engines": {
                 "node": ">=4"
             }
-        },
-        "node_modules/ms": {
-            "version": "2.1.2",
-            "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-            "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-            "dev": true
-        },
-        "node_modules/natural-compare": {
-            "version": "1.4.0",
-            "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
-            "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
-            "dev": true
         },
         "node_modules/noms": {
             "version": "0.0.0",
@@ -1669,50 +692,12 @@
             "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
             "dev": true
         },
-        "node_modules/normalize-path": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
-            "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
-            "dev": true,
-            "engines": {
-                "node": ">=0.10.0"
-            }
-        },
         "node_modules/once": {
             "version": "1.4.0",
             "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
             "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
             "dependencies": {
                 "wrappy": "1"
-            }
-        },
-        "node_modules/optionator": {
-            "version": "0.9.1",
-            "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.1.tgz",
-            "integrity": "sha512-74RlY5FCnhq4jRxVUPKDaRwrVNXMqsGsiW6AJw4XK8hmtm10wC0ypZBLw5IIp85NZMr91+qd1RvvENwg7jjRFw==",
-            "dev": true,
-            "dependencies": {
-                "deep-is": "^0.1.3",
-                "fast-levenshtein": "^2.0.6",
-                "levn": "^0.4.1",
-                "prelude-ls": "^1.2.1",
-                "type-check": "^0.4.0",
-                "word-wrap": "^1.2.3"
-            },
-            "engines": {
-                "node": ">= 0.8.0"
-            }
-        },
-        "node_modules/parent-module": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
-            "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
-            "dev": true,
-            "dependencies": {
-                "callsites": "^3.0.0"
-            },
-            "engines": {
-                "node": ">=6"
             }
         },
         "node_modules/path-is-absolute": {
@@ -1722,42 +707,6 @@
             "dev": true,
             "engines": {
                 "node": ">=0.10.0"
-            }
-        },
-        "node_modules/path-key": {
-            "version": "3.1.1",
-            "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
-            "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
-            "dev": true,
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "node_modules/path-parse": {
-            "version": "1.0.7",
-            "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
-            "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
-            "dev": true
-        },
-        "node_modules/path-type": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
-            "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
-            "dev": true,
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "node_modules/picomatch": {
-            "version": "2.3.0",
-            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.0.tgz",
-            "integrity": "sha512-lY1Q/PiJGC2zOv/z391WOTD+Z02bCgsFfvxoXXf6h7kv9o+WmsmzYqrAwY63sNgOxE4xEdq0WyUnXfKeBrSvYw==",
-            "dev": true,
-            "engines": {
-                "node": ">=8.6"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/jonschlinkert"
             }
         },
         "node_modules/pino": {
@@ -1813,15 +762,6 @@
                 "flatstr": "^1.0.12"
             }
         },
-        "node_modules/prelude-ls": {
-            "version": "1.2.1",
-            "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
-            "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
-            "dev": true,
-            "engines": {
-                "node": ">= 0.8.0"
-            }
-        },
         "node_modules/process-nextick-args": {
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
@@ -1842,35 +782,6 @@
                 "once": "^1.3.1"
             }
         },
-        "node_modules/punycode": {
-            "version": "2.1.1",
-            "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
-            "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
-            "dev": true,
-            "engines": {
-                "node": ">=6"
-            }
-        },
-        "node_modules/queue-microtask": {
-            "version": "1.2.3",
-            "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
-            "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
-            "dev": true,
-            "funding": [
-                {
-                    "type": "github",
-                    "url": "https://github.com/sponsors/feross"
-                },
-                {
-                    "type": "patreon",
-                    "url": "https://www.patreon.com/feross"
-                },
-                {
-                    "type": "consulting",
-                    "url": "https://feross.org/support"
-                }
-            ]
-        },
         "node_modules/quick-format-unescaped": {
             "version": "4.0.3",
             "resolved": "https://registry.npmjs.org/quick-format-unescaped/-/quick-format-unescaped-4.0.3.tgz",
@@ -1889,68 +800,12 @@
                 "node": ">= 6"
             }
         },
-        "node_modules/readdirp": {
-            "version": "3.6.0",
-            "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
-            "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
-            "dev": true,
-            "dependencies": {
-                "picomatch": "^2.2.1"
-            },
-            "engines": {
-                "node": ">=8.10.0"
-            }
-        },
-        "node_modules/regexpp": {
-            "version": "3.2.0",
-            "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-3.2.0.tgz",
-            "integrity": "sha512-pq2bWo9mVD43nbts2wGv17XLiNLya+GklZ8kaDLV2Z08gDCsGpnKn9BFMepvWuHCbyVvY7J5o5+BVvoQbmlJLg==",
-            "dev": true,
-            "engines": {
-                "node": ">=8"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/mysticatea"
-            }
-        },
         "node_modules/require-directory": {
             "version": "2.1.1",
             "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
             "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
             "dev": true,
             "engines": {
-                "node": ">=0.10.0"
-            }
-        },
-        "node_modules/resolve": {
-            "version": "1.20.0",
-            "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.20.0.tgz",
-            "integrity": "sha512-wENBPt4ySzg4ybFQW2TT1zMQucPK95HSh/nq2CFTZVOGut2+pQvSsgtda4d26YrYcr067wjbmzOG8byDPBX63A==",
-            "dev": true,
-            "dependencies": {
-                "is-core-module": "^2.2.0",
-                "path-parse": "^1.0.6"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
-        "node_modules/resolve-from": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
-            "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
-            "dev": true,
-            "engines": {
-                "node": ">=4"
-            }
-        },
-        "node_modules/reusify": {
-            "version": "1.0.4",
-            "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.0.4.tgz",
-            "integrity": "sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==",
-            "dev": true,
-            "engines": {
-                "iojs": ">=1.0.0",
                 "node": ">=0.10.0"
             }
         },
@@ -1974,29 +829,6 @@
                 "url": "https://github.com/sponsors/isaacs"
             }
         },
-        "node_modules/run-parallel": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
-            "integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
-            "dev": true,
-            "funding": [
-                {
-                    "type": "github",
-                    "url": "https://github.com/sponsors/feross"
-                },
-                {
-                    "type": "patreon",
-                    "url": "https://www.patreon.com/feross"
-                },
-                {
-                    "type": "consulting",
-                    "url": "https://feross.org/support"
-                }
-            ],
-            "dependencies": {
-                "queue-microtask": "^1.2.2"
-            }
-        },
         "node_modules/safe-buffer": {
             "version": "5.2.1",
             "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
@@ -2016,76 +848,12 @@
                 }
             ]
         },
-        "node_modules/semver": {
-            "version": "7.3.5",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
-            "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
-            "dev": true,
-            "dependencies": {
-                "lru-cache": "^6.0.0"
-            },
-            "bin": {
-                "semver": "bin/semver.js"
-            },
-            "engines": {
-                "node": ">=10"
-            }
-        },
-        "node_modules/shebang-command": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
-            "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
-            "dev": true,
-            "dependencies": {
-                "shebang-regex": "^3.0.0"
-            },
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "node_modules/shebang-regex": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
-            "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
-            "dev": true,
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "node_modules/slash": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
-            "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
-            "dev": true,
-            "engines": {
-                "node": ">=8"
-            }
-        },
         "node_modules/sonic-boom": {
             "version": "2.6.0",
             "resolved": "https://registry.npmjs.org/sonic-boom/-/sonic-boom-2.6.0.tgz",
             "integrity": "sha512-6xYZFRmDEtxGqfOKcDQ4cPLrNa0SPEDI+wlzDAHowXE6YV42NeXqg9mP2KkiM8JVu3lHfZ2iQKYlGOz+kTpphg==",
             "dependencies": {
                 "atomic-sleep": "^1.0.0"
-            }
-        },
-        "node_modules/source-map": {
-            "version": "0.6.1",
-            "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-            "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-            "dev": true,
-            "engines": {
-                "node": ">=0.10.0"
-            }
-        },
-        "node_modules/source-map-support": {
-            "version": "0.5.21",
-            "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
-            "integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
-            "dev": true,
-            "dependencies": {
-                "buffer-from": "^1.0.0",
-                "source-map": "^0.6.0"
             }
         },
         "node_modules/split2": {
@@ -2135,15 +903,6 @@
                 "node": ">=8"
             }
         },
-        "node_modules/strip-bom": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
-            "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
-            "dev": true,
-            "engines": {
-                "node": ">=4"
-            }
-        },
         "node_modules/strip-json-comments": {
             "version": "3.1.1",
             "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
@@ -2165,12 +924,6 @@
             "engines": {
                 "node": ">=8"
             }
-        },
-        "node_modules/text-table": {
-            "version": "0.2.0",
-            "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
-            "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
-            "dev": true
         },
         "node_modules/through2": {
             "version": "2.0.5",
@@ -2218,182 +971,76 @@
                 "safe-buffer": "~5.1.0"
             }
         },
-        "node_modules/to-regex-range": {
-            "version": "5.0.1",
-            "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
-            "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+        "node_modules/ts-node": {
+            "version": "10.9.2",
+            "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.2.tgz",
+            "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
-                "is-number": "^7.0.0"
-            },
-            "engines": {
-                "node": ">=8.0"
-            }
-        },
-        "node_modules/tree-kill": {
-            "version": "1.2.2",
-            "resolved": "https://registry.npmjs.org/tree-kill/-/tree-kill-1.2.2.tgz",
-            "integrity": "sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==",
-            "dev": true,
-            "bin": {
-                "tree-kill": "cli.js"
-            }
-        },
-        "node_modules/ts-node-dev": {
-            "version": "1.1.8",
-            "resolved": "https://registry.npmjs.org/ts-node-dev/-/ts-node-dev-1.1.8.tgz",
-            "integrity": "sha512-Q/m3vEwzYwLZKmV6/0VlFxcZzVV/xcgOt+Tx/VjaaRHyiBcFlV0541yrT09QjzzCxlDZ34OzKjrFAynlmtflEg==",
-            "dev": true,
-            "dependencies": {
-                "chokidar": "^3.5.1",
-                "dynamic-dedupe": "^0.3.0",
-                "minimist": "^1.2.5",
-                "mkdirp": "^1.0.4",
-                "resolve": "^1.0.0",
-                "rimraf": "^2.6.1",
-                "source-map-support": "^0.5.12",
-                "tree-kill": "^1.2.2",
-                "ts-node": "^9.0.0",
-                "tsconfig": "^7.0.0"
-            },
-            "bin": {
-                "ts-node-dev": "lib/bin.js",
-                "tsnd": "lib/bin.js"
-            },
-            "engines": {
-                "node": ">=0.8.0"
-            },
-            "peerDependencies": {
-                "node-notifier": "*",
-                "typescript": "*"
-            },
-            "peerDependenciesMeta": {
-                "node-notifier": {
-                    "optional": true
-                }
-            }
-        },
-        "node_modules/ts-node-dev/node_modules/rimraf": {
-            "version": "2.7.1",
-            "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
-            "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
-            "dev": true,
-            "dependencies": {
-                "glob": "^7.1.3"
-            },
-            "bin": {
-                "rimraf": "bin.js"
-            }
-        },
-        "node_modules/ts-node-dev/node_modules/ts-node": {
-            "version": "9.1.1",
-            "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-9.1.1.tgz",
-            "integrity": "sha512-hPlt7ZACERQGf03M253ytLY3dHbGNGrAq9qIHWUY9XHYl1z7wYngSr3OQ5xmui8o2AaxsONxIzjafLUiWBo1Fg==",
-            "dev": true,
-            "dependencies": {
+                "@cspotcode/source-map-support": "^0.8.0",
+                "@tsconfig/node10": "^1.0.7",
+                "@tsconfig/node12": "^1.0.7",
+                "@tsconfig/node14": "^1.0.0",
+                "@tsconfig/node16": "^1.0.2",
+                "acorn": "^8.4.1",
+                "acorn-walk": "^8.1.1",
                 "arg": "^4.1.0",
                 "create-require": "^1.1.0",
                 "diff": "^4.0.1",
                 "make-error": "^1.1.1",
-                "source-map-support": "^0.5.17",
+                "v8-compile-cache-lib": "^3.0.1",
                 "yn": "3.1.1"
             },
             "bin": {
                 "ts-node": "dist/bin.js",
+                "ts-node-cwd": "dist/bin-cwd.js",
+                "ts-node-esm": "dist/bin-esm.js",
                 "ts-node-script": "dist/bin-script.js",
                 "ts-node-transpile-only": "dist/bin-transpile.js",
                 "ts-script": "dist/bin-script-deprecated.js"
             },
-            "engines": {
-                "node": ">=10.0.0"
-            },
             "peerDependencies": {
+                "@swc/core": ">=1.2.50",
+                "@swc/wasm": ">=1.2.50",
+                "@types/node": "*",
                 "typescript": ">=2.7"
-            }
-        },
-        "node_modules/tsconfig": {
-            "version": "7.0.0",
-            "resolved": "https://registry.npmjs.org/tsconfig/-/tsconfig-7.0.0.tgz",
-            "integrity": "sha512-vZXmzPrL+EmC4T/4rVlT2jNVMWCi/O4DIiSj3UHg1OE5kCKbk4mfrXc6dZksLgRM/TZlKnousKH9bbTazUWRRw==",
-            "dev": true,
-            "dependencies": {
-                "@types/strip-bom": "^3.0.0",
-                "@types/strip-json-comments": "0.0.30",
-                "strip-bom": "^3.0.0",
-                "strip-json-comments": "^2.0.0"
-            }
-        },
-        "node_modules/tsconfig/node_modules/strip-json-comments": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
-            "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
-            "dev": true,
-            "engines": {
-                "node": ">=0.10.0"
+            },
+            "peerDependenciesMeta": {
+                "@swc/core": {
+                    "optional": true
+                },
+                "@swc/wasm": {
+                    "optional": true
+                }
             }
         },
         "node_modules/tslib": {
-            "version": "2.3.1",
-            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
-            "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
-        },
-        "node_modules/tsutils": {
-            "version": "3.21.0",
-            "resolved": "https://registry.npmjs.org/tsutils/-/tsutils-3.21.0.tgz",
-            "integrity": "sha512-mHKK3iUXL+3UF6xL5k0PEhKRUBKPBCv/+RkEOpjRWxxx27KKRBmmA60A9pgOUvMi8GKhRMPEmjBRPzs2W7O1OA==",
-            "dev": true,
-            "dependencies": {
-                "tslib": "^1.8.1"
-            },
-            "engines": {
-                "node": ">= 6"
-            },
-            "peerDependencies": {
-                "typescript": ">=2.8.0 || >= 3.2.0-dev || >= 3.3.0-dev || >= 3.4.0-dev || >= 3.5.0-dev || >= 3.6.0-dev || >= 3.6.0-beta || >= 3.7.0-dev || >= 3.7.0-beta"
-            }
-        },
-        "node_modules/tsutils/node_modules/tslib": {
-            "version": "1.14.1",
-            "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-            "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
-            "dev": true
-        },
-        "node_modules/type-check": {
-            "version": "0.4.0",
-            "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
-            "integrity": "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==",
-            "dev": true,
-            "dependencies": {
-                "prelude-ls": "^1.2.1"
-            },
-            "engines": {
-                "node": ">= 0.8.0"
-            }
-        },
-        "node_modules/type-fest": {
-            "version": "0.20.2",
-            "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
-            "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
-            "dev": true,
-            "engines": {
-                "node": ">=10"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
+            "version": "2.8.1",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+            "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+            "license": "0BSD"
         },
         "node_modules/typescript": {
-            "version": "4.5.5",
-            "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.5.tgz",
-            "integrity": "sha512-TCTIul70LyWe6IJWT8QSYeA54WQe8EjQFU4wY52Fasj5UKx88LNYKCgBEHcOMOrFF1rKGbD8v/xcNWVUq9SymA==",
+            "version": "5.7.3",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.7.3.tgz",
+            "integrity": "sha512-84MVSjMEHP+FQRPy3pX9sTVV/INIex71s9TL2Gm5FG/WG1SqXeKyZ0k7/blY/4FdOzI12CBy1vGc4og/eus0fw==",
             "dev": true,
+            "license": "Apache-2.0",
             "bin": {
                 "tsc": "bin/tsc",
                 "tsserver": "bin/tsserver"
             },
             "engines": {
-                "node": ">=4.2.0"
+                "node": ">=14.17"
             }
+        },
+        "node_modules/undici-types": {
+            "version": "6.20.0",
+            "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.20.0.tgz",
+            "integrity": "sha512-Ny6QZ2Nju20vw1SRHe3d9jVu6gJ+4e3+MMpqu7pqE5HT6WsTSlce++GQmK5UXS8mzV8DSYHrQH+Xrf2jVcuKNg==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/untildify": {
             "version": "4.0.0",
@@ -2404,49 +1051,17 @@
                 "node": ">=8"
             }
         },
-        "node_modules/uri-js": {
-            "version": "4.4.1",
-            "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
-            "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
-            "dev": true,
-            "dependencies": {
-                "punycode": "^2.1.0"
-            }
-        },
         "node_modules/util-deprecate": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
             "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
         },
-        "node_modules/v8-compile-cache": {
-            "version": "2.3.0",
-            "resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.3.0.tgz",
-            "integrity": "sha512-l8lCEmLcLYZh4nbunNZvQCJc5pv7+RCwa8q/LdUx8u7lsWvPDKmpodJAJNwkAhJC//dFY48KuIEmjtd4RViDrA==",
-            "dev": true
-        },
-        "node_modules/which": {
-            "version": "2.0.2",
-            "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
-            "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+        "node_modules/v8-compile-cache-lib": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
+            "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
             "dev": true,
-            "dependencies": {
-                "isexe": "^2.0.0"
-            },
-            "bin": {
-                "node-which": "bin/node-which"
-            },
-            "engines": {
-                "node": ">= 8"
-            }
-        },
-        "node_modules/word-wrap": {
-            "version": "1.2.3",
-            "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
-            "integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==",
-            "dev": true,
-            "engines": {
-                "node": ">=0.10.0"
-            }
+            "license": "MIT"
         },
         "node_modules/wrap-ansi": {
             "version": "7.0.0",
@@ -2488,12 +1103,6 @@
                 "node": ">=10"
             }
         },
-        "node_modules/yallist": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-            "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-            "dev": true
-        },
         "node_modules/yargs": {
             "version": "16.2.0",
             "resolved": "https://registry.npmjs.org/yargs/-/yargs-16.2.0.tgz",
@@ -2532,38 +1141,13 @@
         }
     },
     "dependencies": {
-        "@eslint/eslintrc": {
-            "version": "1.2.1",
-            "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-1.2.1.tgz",
-            "integrity": "sha512-bxvbYnBPN1Gibwyp6NrpnFzA3YtRL3BBAyEAFVIpNTm2Rn4Vy87GA5M4aSn3InRrlsbX5N0GW7XIx+U4SAEKdQ==",
+        "@cspotcode/source-map-support": {
+            "version": "0.8.1",
+            "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
+            "integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
             "dev": true,
             "requires": {
-                "ajv": "^6.12.4",
-                "debug": "^4.3.2",
-                "espree": "^9.3.1",
-                "globals": "^13.9.0",
-                "ignore": "^5.2.0",
-                "import-fresh": "^3.2.1",
-                "js-yaml": "^4.1.0",
-                "minimatch": "^3.0.4",
-                "strip-json-comments": "^3.1.1"
-            },
-            "dependencies": {
-                "argparse": {
-                    "version": "2.0.1",
-                    "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
-                    "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-                    "dev": true
-                },
-                "js-yaml": {
-                    "version": "4.1.0",
-                    "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
-                    "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
-                    "dev": true,
-                    "requires": {
-                        "argparse": "^2.0.1"
-                    }
-                }
+                "@jridgewell/trace-mapping": "0.3.9"
             }
         },
         "@hapi/bourne": {
@@ -2571,69 +1155,60 @@
             "resolved": "https://registry.npmjs.org/@hapi/bourne/-/bourne-2.0.0.tgz",
             "integrity": "sha512-WEezM1FWztfbzqIUbsDzFRVMxSoLy3HugVcux6KDDtTqzPsLE8NDRHfXvev66aH1i2oOKKar3/XDjbvh/OUBdg=="
         },
-        "@humanwhocodes/config-array": {
-            "version": "0.9.5",
-            "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.9.5.tgz",
-            "integrity": "sha512-ObyMyWxZiCu/yTisA7uzx81s40xR2fD5Cg/2Kq7G02ajkNubJf6BopgDTmDyc3U7sXpNKM8cYOw7s7Tyr+DnCw==",
-            "dev": true,
-            "requires": {
-                "@humanwhocodes/object-schema": "^1.2.1",
-                "debug": "^4.1.1",
-                "minimatch": "^3.0.4"
-            }
-        },
-        "@humanwhocodes/object-schema": {
-            "version": "1.2.1",
-            "resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-1.2.1.tgz",
-            "integrity": "sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==",
+        "@jridgewell/resolve-uri": {
+            "version": "3.1.2",
+            "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+            "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
             "dev": true
         },
-        "@nodelib/fs.scandir": {
-            "version": "2.1.5",
-            "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
-            "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
-            "dev": true,
-            "requires": {
-                "@nodelib/fs.stat": "2.0.5",
-                "run-parallel": "^1.1.9"
-            }
-        },
-        "@nodelib/fs.stat": {
-            "version": "2.0.5",
-            "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
-            "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
+        "@jridgewell/sourcemap-codec": {
+            "version": "1.5.0",
+            "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.0.tgz",
+            "integrity": "sha512-gv3ZRaISU3fjPAgNsriBRqGWQL6quFx04YMPW/zD8XMLsU32mhCCbfbO6KZFLjvYpCZ8zyDEgqsgf+PwPaM7GQ==",
             "dev": true
         },
-        "@nodelib/fs.walk": {
-            "version": "1.2.8",
-            "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
-            "integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
+        "@jridgewell/trace-mapping": {
+            "version": "0.3.9",
+            "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
+            "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
             "dev": true,
             "requires": {
-                "@nodelib/fs.scandir": "2.1.5",
-                "fastq": "^1.6.0"
+                "@jridgewell/resolve-uri": "^3.0.3",
+                "@jridgewell/sourcemap-codec": "^1.4.10"
             }
         },
-        "@runejs/eslint-config": {
-            "version": "file:../eslint-config",
-            "requires": {
-                "@typescript-eslint/eslint-plugin": "^5.14.0",
-                "@typescript-eslint/parser": "^5.14.0",
-                "eslint": "^8.11.0",
-                "typescript": "^4.5.5"
-            }
+        "@tsconfig/node10": {
+            "version": "1.0.11",
+            "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.11.tgz",
+            "integrity": "sha512-DcRjDCujK/kCk/cUe8Xz8ZSpm8mS3mNNpta+jGCA6USEDfktlNvm1+IuZ9eTcDbNk41BHwpHHeW+N1lKCz4zOw==",
+            "dev": true
         },
-        "@types/json-schema": {
-            "version": "7.0.9",
-            "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.9.tgz",
-            "integrity": "sha512-qcUXuemtEu+E5wZSJHNxUXeCZhAfXKQ41D+duX+VYPde7xyEVZci+/oXKJL13tnRs9lR2pr4fod59GT6/X1/yQ==",
+        "@tsconfig/node12": {
+            "version": "1.0.11",
+            "resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.11.tgz",
+            "integrity": "sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==",
+            "dev": true
+        },
+        "@tsconfig/node14": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.3.tgz",
+            "integrity": "sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==",
+            "dev": true
+        },
+        "@tsconfig/node16": {
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.4.tgz",
+            "integrity": "sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==",
             "dev": true
         },
         "@types/node": {
-            "version": "16.11.26",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-16.11.26.tgz",
-            "integrity": "sha512-GZ7bu5A6+4DtG7q9GsoHXy3ALcgeIHP4NnL0Vv2wu0uUB/yQex26v0tf6/na1mm0+bS9Uw+0DFex7aaKr2qawQ==",
-            "dev": true
+            "version": "22.10.7",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-22.10.7.tgz",
+            "integrity": "sha512-V09KvXxFiutGp6B7XkpaDXlNadZxrzajcY50EuoLIpQ6WWYCSvf19lVIazzfIzQvhUN2HjX12spLojTnhuKlGg==",
+            "dev": true,
+            "requires": {
+                "undici-types": "~6.20.0"
+            }
         },
         "@types/pino": {
             "version": "6.3.12",
@@ -2665,136 +1240,19 @@
                 "@types/node": "*"
             }
         },
-        "@types/strip-bom": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/@types/strip-bom/-/strip-bom-3.0.0.tgz",
-            "integrity": "sha1-FKjsOVbC6B7bdSB5CuzyHCkK69I=",
-            "dev": true
-        },
-        "@types/strip-json-comments": {
-            "version": "0.0.30",
-            "resolved": "https://registry.npmjs.org/@types/strip-json-comments/-/strip-json-comments-0.0.30.tgz",
-            "integrity": "sha512-7NQmHra/JILCd1QqpSzl8+mJRc8ZHz3uDm8YV1Ks9IhK0epEiTw8aIErbvH9PI+6XbqhyIQy3462nEsn7UVzjQ==",
-            "dev": true
-        },
-        "@typescript-eslint/eslint-plugin": {
-            "version": "5.14.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.14.0.tgz",
-            "integrity": "sha512-ir0wYI4FfFUDfLcuwKzIH7sMVA+db7WYen47iRSaCGl+HMAZI9fpBwfDo45ZALD3A45ZGyHWDNLhbg8tZrMX4w==",
-            "dev": true,
-            "requires": {
-                "@typescript-eslint/scope-manager": "5.14.0",
-                "@typescript-eslint/type-utils": "5.14.0",
-                "@typescript-eslint/utils": "5.14.0",
-                "debug": "^4.3.2",
-                "functional-red-black-tree": "^1.0.1",
-                "ignore": "^5.1.8",
-                "regexpp": "^3.2.0",
-                "semver": "^7.3.5",
-                "tsutils": "^3.21.0"
-            }
-        },
-        "@typescript-eslint/parser": {
-            "version": "5.14.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.14.0.tgz",
-            "integrity": "sha512-aHJN8/FuIy1Zvqk4U/gcO/fxeMKyoSv/rS46UXMXOJKVsLQ+iYPuXNbpbH7cBLcpSbmyyFbwrniLx5+kutu1pw==",
-            "dev": true,
-            "requires": {
-                "@typescript-eslint/scope-manager": "5.14.0",
-                "@typescript-eslint/types": "5.14.0",
-                "@typescript-eslint/typescript-estree": "5.14.0",
-                "debug": "^4.3.2"
-            }
-        },
-        "@typescript-eslint/scope-manager": {
-            "version": "5.14.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.14.0.tgz",
-            "integrity": "sha512-LazdcMlGnv+xUc5R4qIlqH0OWARyl2kaP8pVCS39qSL3Pd1F7mI10DbdXeARcE62sVQE4fHNvEqMWsypWO+yEw==",
-            "dev": true,
-            "requires": {
-                "@typescript-eslint/types": "5.14.0",
-                "@typescript-eslint/visitor-keys": "5.14.0"
-            }
-        },
-        "@typescript-eslint/type-utils": {
-            "version": "5.14.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.14.0.tgz",
-            "integrity": "sha512-d4PTJxsqaUpv8iERTDSQBKUCV7Q5yyXjqXUl3XF7Sd9ogNLuKLkxz82qxokqQ4jXdTPZudWpmNtr/JjbbvUixw==",
-            "dev": true,
-            "requires": {
-                "@typescript-eslint/utils": "5.14.0",
-                "debug": "^4.3.2",
-                "tsutils": "^3.21.0"
-            }
-        },
-        "@typescript-eslint/types": {
-            "version": "5.14.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.14.0.tgz",
-            "integrity": "sha512-BR6Y9eE9360LNnW3eEUqAg6HxS9Q35kSIs4rp4vNHRdfg0s+/PgHgskvu5DFTM7G5VKAVjuyaN476LCPrdA7Mw==",
-            "dev": true
-        },
-        "@typescript-eslint/typescript-estree": {
-            "version": "5.14.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.14.0.tgz",
-            "integrity": "sha512-QGnxvROrCVtLQ1724GLTHBTR0lZVu13izOp9njRvMkCBgWX26PKvmMP8k82nmXBRD3DQcFFq2oj3cKDwr0FaUA==",
-            "dev": true,
-            "requires": {
-                "@typescript-eslint/types": "5.14.0",
-                "@typescript-eslint/visitor-keys": "5.14.0",
-                "debug": "^4.3.2",
-                "globby": "^11.0.4",
-                "is-glob": "^4.0.3",
-                "semver": "^7.3.5",
-                "tsutils": "^3.21.0"
-            }
-        },
-        "@typescript-eslint/utils": {
-            "version": "5.14.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.14.0.tgz",
-            "integrity": "sha512-EHwlII5mvUA0UsKYnVzySb/5EE/t03duUTweVy8Zqt3UQXBrpEVY144OTceFKaOe4xQXZJrkptCf7PjEBeGK4w==",
-            "dev": true,
-            "requires": {
-                "@types/json-schema": "^7.0.9",
-                "@typescript-eslint/scope-manager": "5.14.0",
-                "@typescript-eslint/types": "5.14.0",
-                "@typescript-eslint/typescript-estree": "5.14.0",
-                "eslint-scope": "^5.1.1",
-                "eslint-utils": "^3.0.0"
-            }
-        },
-        "@typescript-eslint/visitor-keys": {
-            "version": "5.14.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.14.0.tgz",
-            "integrity": "sha512-yL0XxfzR94UEkjBqyymMLgCBdojzEuy/eim7N9/RIcTNxpJudAcqsU8eRyfzBbcEzGoPWfdM3AGak3cN08WOIw==",
-            "dev": true,
-            "requires": {
-                "@typescript-eslint/types": "5.14.0",
-                "eslint-visitor-keys": "^3.0.0"
-            }
-        },
         "acorn": {
-            "version": "8.7.0",
-            "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.7.0.tgz",
-            "integrity": "sha512-V/LGr1APy+PXIwKebEWrkZPwoeoF+w1jiOBUmuxuiUIaOHtob8Qc9BTrYo7VuI5fR8tqsy+buA2WFooR5olqvQ==",
+            "version": "8.14.0",
+            "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.14.0.tgz",
+            "integrity": "sha512-cl669nCJTZBsL97OF4kUQm5g5hC2uihk0NxY3WENAC0TYdILVkAyHymAntgxGkl7K+t0cXIrH5siy5S4XkFycA==",
             "dev": true
         },
-        "acorn-jsx": {
-            "version": "5.3.2",
-            "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
-            "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
-            "dev": true,
-            "requires": {}
-        },
-        "ajv": {
-            "version": "6.12.6",
-            "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
-            "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+        "acorn-walk": {
+            "version": "8.3.4",
+            "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.4.tgz",
+            "integrity": "sha512-ueEepnujpqee2o5aIYnvHU6C0A42MNdsIDeqy5BydrkuC5R1ZuUFnm27EeFJGoEHJQgn3uleRvmTXaJgfXbt4g==",
             "dev": true,
             "requires": {
-                "fast-deep-equal": "^3.1.1",
-                "fast-json-stable-stringify": "^2.0.0",
-                "json-schema-traverse": "^0.4.1",
-                "uri-js": "^4.2.2"
+                "acorn": "^8.11.0"
             }
         },
         "amdefine": {
@@ -2814,16 +1272,6 @@
             "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
             "requires": {
                 "color-convert": "^2.0.1"
-            }
-        },
-        "anymatch": {
-            "version": "3.1.2",
-            "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.2.tgz",
-            "integrity": "sha512-P43ePfOAIupkguHUycrc4qJ9kz8ZiuOUijaETwX7THt0Y/GNK7v0aa8rY816xWjZ7rJdA5XdMcpVFTKMq+RvWg==",
-            "dev": true,
-            "requires": {
-                "normalize-path": "^3.0.0",
-                "picomatch": "^2.0.4"
             }
         },
         "arg": {
@@ -2897,12 +1345,6 @@
                 }
             }
         },
-        "array-union": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
-            "integrity": "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==",
-            "dev": true
-        },
         "atomic-sleep": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/atomic-sleep/-/atomic-sleep-1.0.0.tgz",
@@ -2914,12 +1356,6 @@
             "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
             "dev": true
         },
-        "binary-extensions": {
-            "version": "2.2.0",
-            "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.2.0.tgz",
-            "integrity": "sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==",
-            "dev": true
-        },
         "brace-expansion": {
             "version": "1.1.11",
             "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
@@ -2929,27 +1365,6 @@
                 "balanced-match": "^1.0.0",
                 "concat-map": "0.0.1"
             }
-        },
-        "braces": {
-            "version": "3.0.2",
-            "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
-            "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
-            "dev": true,
-            "requires": {
-                "fill-range": "^7.0.1"
-            }
-        },
-        "buffer-from": {
-            "version": "1.1.2",
-            "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
-            "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
-            "dev": true
-        },
-        "callsites": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
-            "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
-            "dev": true
         },
         "camelcase": {
             "version": "5.0.0",
@@ -2963,22 +1378,6 @@
             "requires": {
                 "ansi-styles": "^4.1.0",
                 "supports-color": "^7.1.0"
-            }
-        },
-        "chokidar": {
-            "version": "3.5.2",
-            "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.5.2.tgz",
-            "integrity": "sha512-ekGhOnNVPgT77r4K/U3GDhu+FQ2S8TnK/s2KbIGXi0SZWuwkZ2QNyfWdZW+TVfn84DpEP7rLeCt2UI6bJ8GwbQ==",
-            "dev": true,
-            "requires": {
-                "anymatch": "~3.1.2",
-                "braces": "~3.0.2",
-                "fsevents": "~2.3.2",
-                "glob-parent": "~5.1.2",
-                "is-binary-path": "~2.1.0",
-                "is-glob": "~4.0.1",
-                "normalize-path": "~3.0.0",
-                "readdirp": "~3.6.0"
             }
         },
         "cliui": {
@@ -3055,69 +1454,16 @@
             "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
             "dev": true
         },
-        "cross-spawn": {
-            "version": "7.0.3",
-            "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
-            "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
-            "dev": true,
-            "requires": {
-                "path-key": "^3.1.0",
-                "shebang-command": "^2.0.0",
-                "which": "^2.0.1"
-            }
-        },
         "dateformat": {
             "version": "4.5.1",
             "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-4.5.1.tgz",
             "integrity": "sha512-OD0TZ+B7yP7ZgpJf5K2DIbj3FZvFvxgFUuaqA/V5zTjAtAAXZ1E8bktHxmAGs4x5b7PflqA9LeQ84Og7wYtF7Q=="
-        },
-        "debug": {
-            "version": "4.3.2",
-            "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.2.tgz",
-            "integrity": "sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==",
-            "dev": true,
-            "requires": {
-                "ms": "2.1.2"
-            }
-        },
-        "deep-is": {
-            "version": "0.1.3",
-            "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
-            "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=",
-            "dev": true
         },
         "diff": {
             "version": "4.0.2",
             "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
             "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
             "dev": true
-        },
-        "dir-glob": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-3.0.1.tgz",
-            "integrity": "sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==",
-            "dev": true,
-            "requires": {
-                "path-type": "^4.0.0"
-            }
-        },
-        "doctrine": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-3.0.0.tgz",
-            "integrity": "sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==",
-            "dev": true,
-            "requires": {
-                "esutils": "^2.0.2"
-            }
-        },
-        "dynamic-dedupe": {
-            "version": "0.3.0",
-            "resolved": "https://registry.npmjs.org/dynamic-dedupe/-/dynamic-dedupe-0.3.0.tgz",
-            "integrity": "sha1-BuRMIj9eTpTXjvnbI6ZRXOL5YqE=",
-            "dev": true,
-            "requires": {
-                "xtend": "^4.0.0"
-            }
         },
         "emoji-regex": {
             "version": "8.0.0",
@@ -3144,222 +1490,10 @@
             "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
             "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
         },
-        "eslint": {
-            "version": "8.11.0",
-            "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.11.0.tgz",
-            "integrity": "sha512-/KRpd9mIRg2raGxHRGwW9ZywYNAClZrHjdueHcrVDuO3a6bj83eoTirCCk0M0yPwOjWYKHwRVRid+xK4F/GHgA==",
-            "dev": true,
-            "requires": {
-                "@eslint/eslintrc": "^1.2.1",
-                "@humanwhocodes/config-array": "^0.9.2",
-                "ajv": "^6.10.0",
-                "chalk": "^4.0.0",
-                "cross-spawn": "^7.0.2",
-                "debug": "^4.3.2",
-                "doctrine": "^3.0.0",
-                "escape-string-regexp": "^4.0.0",
-                "eslint-scope": "^7.1.1",
-                "eslint-utils": "^3.0.0",
-                "eslint-visitor-keys": "^3.3.0",
-                "espree": "^9.3.1",
-                "esquery": "^1.4.0",
-                "esutils": "^2.0.2",
-                "fast-deep-equal": "^3.1.3",
-                "file-entry-cache": "^6.0.1",
-                "functional-red-black-tree": "^1.0.1",
-                "glob-parent": "^6.0.1",
-                "globals": "^13.6.0",
-                "ignore": "^5.2.0",
-                "import-fresh": "^3.0.0",
-                "imurmurhash": "^0.1.4",
-                "is-glob": "^4.0.0",
-                "js-yaml": "^4.1.0",
-                "json-stable-stringify-without-jsonify": "^1.0.1",
-                "levn": "^0.4.1",
-                "lodash.merge": "^4.6.2",
-                "minimatch": "^3.0.4",
-                "natural-compare": "^1.4.0",
-                "optionator": "^0.9.1",
-                "regexpp": "^3.2.0",
-                "strip-ansi": "^6.0.1",
-                "strip-json-comments": "^3.1.0",
-                "text-table": "^0.2.0",
-                "v8-compile-cache": "^2.0.3"
-            },
-            "dependencies": {
-                "argparse": {
-                    "version": "2.0.1",
-                    "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
-                    "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-                    "dev": true
-                },
-                "escape-string-regexp": {
-                    "version": "4.0.0",
-                    "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
-                    "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
-                    "dev": true
-                },
-                "eslint-scope": {
-                    "version": "7.1.1",
-                    "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-7.1.1.tgz",
-                    "integrity": "sha512-QKQM/UXpIiHcLqJ5AOyIW7XZmzjkzQXYE54n1++wb0u9V/abW3l9uQnxX8Z5Xd18xyKIMTUAyQ0k1e8pz6LUrw==",
-                    "dev": true,
-                    "requires": {
-                        "esrecurse": "^4.3.0",
-                        "estraverse": "^5.2.0"
-                    }
-                },
-                "estraverse": {
-                    "version": "5.3.0",
-                    "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
-                    "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
-                    "dev": true
-                },
-                "glob-parent": {
-                    "version": "6.0.2",
-                    "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
-                    "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
-                    "dev": true,
-                    "requires": {
-                        "is-glob": "^4.0.3"
-                    }
-                },
-                "js-yaml": {
-                    "version": "4.1.0",
-                    "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
-                    "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
-                    "dev": true,
-                    "requires": {
-                        "argparse": "^2.0.1"
-                    }
-                }
-            }
-        },
-        "eslint-scope": {
-            "version": "5.1.1",
-            "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.1.1.tgz",
-            "integrity": "sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==",
-            "dev": true,
-            "requires": {
-                "esrecurse": "^4.3.0",
-                "estraverse": "^4.1.1"
-            }
-        },
-        "eslint-utils": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-3.0.0.tgz",
-            "integrity": "sha512-uuQC43IGctw68pJA1RgbQS8/NP7rch6Cwd4j3ZBtgo4/8Flj4eGE7ZYSZRN3iq5pVUv6GPdW5Z1RFleo84uLDA==",
-            "dev": true,
-            "requires": {
-                "eslint-visitor-keys": "^2.0.0"
-            },
-            "dependencies": {
-                "eslint-visitor-keys": {
-                    "version": "2.1.0",
-                    "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-2.1.0.tgz",
-                    "integrity": "sha512-0rSmRBzXgDzIsD6mGdJgevzgezI534Cer5L/vyMX0kHzT/jiB43jRhd9YUlMGYLQy2zprNmoT8qasCGtY+QaKw==",
-                    "dev": true
-                }
-            }
-        },
-        "eslint-visitor-keys": {
-            "version": "3.3.0",
-            "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.3.0.tgz",
-            "integrity": "sha512-mQ+suqKJVyeuwGYHAdjMFqjCyfl8+Ldnxuyp3ldiMBFKkvytrXUZWaiPCEav8qDHKty44bD+qV1IP4T+w+xXRA==",
-            "dev": true
-        },
-        "espree": {
-            "version": "9.3.1",
-            "resolved": "https://registry.npmjs.org/espree/-/espree-9.3.1.tgz",
-            "integrity": "sha512-bvdyLmJMfwkV3NCRl5ZhJf22zBFo1y8bYh3VYb+bfzqNB4Je68P2sSuXyuFquzWLebHpNd2/d5uv7yoP9ISnGQ==",
-            "dev": true,
-            "requires": {
-                "acorn": "^8.7.0",
-                "acorn-jsx": "^5.3.1",
-                "eslint-visitor-keys": "^3.3.0"
-            }
-        },
         "esprima": {
             "version": "4.0.1",
             "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
             "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A=="
-        },
-        "esquery": {
-            "version": "1.4.0",
-            "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.4.0.tgz",
-            "integrity": "sha512-cCDispWt5vHHtwMY2YrAQ4ibFkAL8RbH5YGBnZBc90MolvvfkkQcJro/aZiAQUlQ3qgrYS6D6v8Gc5G5CQsc9w==",
-            "dev": true,
-            "requires": {
-                "estraverse": "^5.1.0"
-            },
-            "dependencies": {
-                "estraverse": {
-                    "version": "5.2.0",
-                    "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.2.0.tgz",
-                    "integrity": "sha512-BxbNGGNm0RyRYvUdHpIwv9IWzeM9XClbOxwoATuFdOE7ZE6wHL+HQ5T8hoPM+zHvmKzzsEqhgy0GrQ5X13afiQ==",
-                    "dev": true
-                }
-            }
-        },
-        "esrecurse": {
-            "version": "4.3.0",
-            "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
-            "integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
-            "dev": true,
-            "requires": {
-                "estraverse": "^5.2.0"
-            },
-            "dependencies": {
-                "estraverse": {
-                    "version": "5.3.0",
-                    "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
-                    "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
-                    "dev": true
-                }
-            }
-        },
-        "estraverse": {
-            "version": "4.3.0",
-            "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz",
-            "integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
-            "dev": true
-        },
-        "esutils": {
-            "version": "2.0.3",
-            "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
-            "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
-            "dev": true
-        },
-        "fast-deep-equal": {
-            "version": "3.1.3",
-            "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
-            "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
-            "dev": true
-        },
-        "fast-glob": {
-            "version": "3.2.11",
-            "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.11.tgz",
-            "integrity": "sha512-xrO3+1bxSo3ZVHAnqzyuewYT6aMFHRAd4Kcs92MAonjwQZLsK9d0SF1IyQ3k5PoirxTW0Oe/RqFgMQ6TcNE5Ew==",
-            "dev": true,
-            "requires": {
-                "@nodelib/fs.stat": "^2.0.2",
-                "@nodelib/fs.walk": "^1.2.3",
-                "glob-parent": "^5.1.2",
-                "merge2": "^1.3.0",
-                "micromatch": "^4.0.4"
-            }
-        },
-        "fast-json-stable-stringify": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
-            "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
-            "dev": true
-        },
-        "fast-levenshtein": {
-            "version": "2.0.6",
-            "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
-            "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
-            "dev": true
         },
         "fast-redact": {
             "version": "3.0.1",
@@ -3371,77 +1505,15 @@
             "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.0.8.tgz",
             "integrity": "sha512-lXatBjf3WPjmWD6DpIZxkeSsCOwqI0maYMpgDlx8g4U2qi4lbjA9oH/HD2a87G+KfsUmo5WbJFmqBZlPxtptag=="
         },
-        "fastq": {
-            "version": "1.13.0",
-            "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.13.0.tgz",
-            "integrity": "sha512-YpkpUnK8od0o1hmeSc7UUs/eB/vIPWJYjKck2QKIzAf71Vm1AAQ3EbuZB3g2JIy+pg+ERD0vqI79KyZiB2e2Nw==",
-            "dev": true,
-            "requires": {
-                "reusify": "^1.0.4"
-            }
-        },
-        "file-entry-cache": {
-            "version": "6.0.1",
-            "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-6.0.1.tgz",
-            "integrity": "sha512-7Gps/XWymbLk2QLYK4NzpMOrYjMhdIxXuIvy2QBsLE6ljuodKvdkWs/cpyJJ3CVIVpH0Oi1Hvg1ovbMzLdFBBg==",
-            "dev": true,
-            "requires": {
-                "flat-cache": "^3.0.4"
-            }
-        },
-        "fill-range": {
-            "version": "7.0.1",
-            "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
-            "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
-            "dev": true,
-            "requires": {
-                "to-regex-range": "^5.0.1"
-            }
-        },
-        "flat-cache": {
-            "version": "3.0.4",
-            "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-3.0.4.tgz",
-            "integrity": "sha512-dm9s5Pw7Jc0GvMYbshN6zchCA9RgQlzzEZX3vylR9IqFfS8XciblUXOKfW6SiuJ0e13eDYZoZV5wdrev7P3Nwg==",
-            "dev": true,
-            "requires": {
-                "flatted": "^3.1.0",
-                "rimraf": "^3.0.2"
-            }
-        },
         "flatstr": {
             "version": "1.0.12",
             "resolved": "https://registry.npmjs.org/flatstr/-/flatstr-1.0.12.tgz",
             "integrity": "sha512-4zPxDyhCyiN2wIAtSLI6gc82/EjqZc1onI4Mz/l0pWrAlsSfYH/2ZIcU+e3oA2wDwbzIWNKwa23F8rh6+DRWkw=="
         },
-        "flatted": {
-            "version": "3.2.2",
-            "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.2.2.tgz",
-            "integrity": "sha512-JaTY/wtrcSyvXJl4IMFHPKyFur1sE9AUqc0QnhOaJ0CxHtAoIV8pYDzeEfAaNEtGkOfq4gr3LBFmdXW5mOQFnA==",
-            "dev": true
-        },
         "fs.realpath": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
             "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
-            "dev": true
-        },
-        "fsevents": {
-            "version": "2.3.2",
-            "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
-            "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
-            "dev": true,
-            "optional": true
-        },
-        "function-bind": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
-            "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
-            "dev": true
-        },
-        "functional-red-black-tree": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
-            "integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=",
             "dev": true
         },
         "get-caller-file": {
@@ -3464,78 +1536,15 @@
                 "path-is-absolute": "^1.0.0"
             }
         },
-        "glob-parent": {
-            "version": "5.1.2",
-            "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
-            "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
-            "dev": true,
-            "requires": {
-                "is-glob": "^4.0.1"
-            }
-        },
-        "globals": {
-            "version": "13.12.1",
-            "resolved": "https://registry.npmjs.org/globals/-/globals-13.12.1.tgz",
-            "integrity": "sha512-317dFlgY2pdJZ9rspXDks7073GpDmXdfbM3vYYp0HAMKGDh1FfWPleI2ljVNLQX5M5lXcAslTcPTrOrMEFOjyw==",
-            "dev": true,
-            "requires": {
-                "type-fest": "^0.20.2"
-            }
-        },
-        "globby": {
-            "version": "11.1.0",
-            "resolved": "https://registry.npmjs.org/globby/-/globby-11.1.0.tgz",
-            "integrity": "sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==",
-            "dev": true,
-            "requires": {
-                "array-union": "^2.1.0",
-                "dir-glob": "^3.0.1",
-                "fast-glob": "^3.2.9",
-                "ignore": "^5.2.0",
-                "merge2": "^1.4.1",
-                "slash": "^3.0.0"
-            }
-        },
         "graceful-readlink": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz",
             "integrity": "sha1-TK+tdrxi8C+gObL5Tpo906ORpyU="
         },
-        "has": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
-            "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
-            "dev": true,
-            "requires": {
-                "function-bind": "^1.1.1"
-            }
-        },
         "has-flag": {
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
             "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
-        },
-        "ignore": {
-            "version": "5.2.0",
-            "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.2.0.tgz",
-            "integrity": "sha512-CmxgYGiEPCLhfLnpPp1MoRmifwEIOgjcHXxOBjv7mY96c+eWScsOP9c112ZyLdWHi0FxHjI+4uVhKYp/gcdRmQ==",
-            "dev": true
-        },
-        "import-fresh": {
-            "version": "3.3.0",
-            "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.0.tgz",
-            "integrity": "sha512-veYYhQa+D1QBKznvhUHxb8faxlrwUnxseDAbAp457E0wLNio2bOSKnjYDhMj+YiAq61xrMGhQk9iXVk5FzgQMw==",
-            "dev": true,
-            "requires": {
-                "parent-module": "^1.0.0",
-                "resolve-from": "^4.0.0"
-            }
-        },
-        "imurmurhash": {
-            "version": "0.1.4",
-            "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
-            "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
-            "dev": true
         },
         "inflight": {
             "version": "1.0.6",
@@ -3552,61 +1561,16 @@
             "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
             "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
         },
-        "is-binary-path": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
-            "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
-            "dev": true,
-            "requires": {
-                "binary-extensions": "^2.0.0"
-            }
-        },
-        "is-core-module": {
-            "version": "2.8.0",
-            "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.8.0.tgz",
-            "integrity": "sha512-vd15qHsaqrRL7dtH6QNuy0ndJmRDrS9HAM1CAiSifNUFv4x1a0CCVsj18hJ1mShxIG6T2i1sO78MkP56r0nYRw==",
-            "dev": true,
-            "requires": {
-                "has": "^1.0.3"
-            }
-        },
-        "is-extglob": {
-            "version": "2.1.1",
-            "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
-            "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
-            "dev": true
-        },
         "is-fullwidth-code-point": {
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
             "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
             "dev": true
         },
-        "is-glob": {
-            "version": "4.0.3",
-            "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
-            "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
-            "dev": true,
-            "requires": {
-                "is-extglob": "^2.1.1"
-            }
-        },
-        "is-number": {
-            "version": "7.0.0",
-            "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
-            "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
-            "dev": true
-        },
         "isarray": {
             "version": "0.0.1",
             "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
             "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
-            "dev": true
-        },
-        "isexe": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-            "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
             "dev": true
         },
         "jmespath": {
@@ -3628,69 +1592,16 @@
                 "esprima": "^4.0.0"
             }
         },
-        "json-schema-traverse": {
-            "version": "0.4.1",
-            "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-            "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
-            "dev": true
-        },
-        "json-stable-stringify-without-jsonify": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
-            "integrity": "sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=",
-            "dev": true
-        },
         "leven": {
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/leven/-/leven-2.1.0.tgz",
             "integrity": "sha1-wuep93IJTe6dNCAq6KzORoeHVYA="
-        },
-        "levn": {
-            "version": "0.4.1",
-            "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
-            "integrity": "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==",
-            "dev": true,
-            "requires": {
-                "prelude-ls": "^1.2.1",
-                "type-check": "~0.4.0"
-            }
-        },
-        "lodash.merge": {
-            "version": "4.6.2",
-            "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
-            "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
-            "dev": true
-        },
-        "lru-cache": {
-            "version": "6.0.0",
-            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-            "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-            "dev": true,
-            "requires": {
-                "yallist": "^4.0.0"
-            }
         },
         "make-error": {
             "version": "1.3.6",
             "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
             "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
             "dev": true
-        },
-        "merge2": {
-            "version": "1.4.1",
-            "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
-            "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
-            "dev": true
-        },
-        "micromatch": {
-            "version": "4.0.4",
-            "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.4.tgz",
-            "integrity": "sha512-pRmzw/XUcwXGpD9aI9q/0XOwLNygjETJ8y0ao0wdqprrzDa4YnxLcz7fQRZr8voh8V10kGhABbNcHVk5wHgWwg==",
-            "dev": true,
-            "requires": {
-                "braces": "^3.0.1",
-                "picomatch": "^2.2.3"
-            }
         },
         "minimatch": {
             "version": "3.0.4",
@@ -3700,12 +1611,6 @@
             "requires": {
                 "brace-expansion": "^1.1.7"
             }
-        },
-        "minimist": {
-            "version": "1.2.5",
-            "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-            "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
-            "dev": true
         },
         "mkdirp": {
             "version": "1.0.4",
@@ -3717,18 +1622,6 @@
             "version": "1.1.4",
             "resolved": "https://registry.npmjs.org/mri/-/mri-1.1.4.tgz",
             "integrity": "sha512-6y7IjGPm8AzlvoUrwAaw1tLnUBudaS3752vcd8JtrpGGQn+rXIe63LFVHm/YMwtqAuh+LJPCFdlLYPWM1nYn6w=="
-        },
-        "ms": {
-            "version": "2.1.2",
-            "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-            "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-            "dev": true
-        },
-        "natural-compare": {
-            "version": "1.4.0",
-            "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
-            "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
-            "dev": true
         },
         "noms": {
             "version": "0.0.0",
@@ -3760,12 +1653,6 @@
                 }
             }
         },
-        "normalize-path": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
-            "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
-            "dev": true
-        },
         "once": {
             "version": "1.4.0",
             "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
@@ -3774,57 +1661,10 @@
                 "wrappy": "1"
             }
         },
-        "optionator": {
-            "version": "0.9.1",
-            "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.1.tgz",
-            "integrity": "sha512-74RlY5FCnhq4jRxVUPKDaRwrVNXMqsGsiW6AJw4XK8hmtm10wC0ypZBLw5IIp85NZMr91+qd1RvvENwg7jjRFw==",
-            "dev": true,
-            "requires": {
-                "deep-is": "^0.1.3",
-                "fast-levenshtein": "^2.0.6",
-                "levn": "^0.4.1",
-                "prelude-ls": "^1.2.1",
-                "type-check": "^0.4.0",
-                "word-wrap": "^1.2.3"
-            }
-        },
-        "parent-module": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
-            "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
-            "dev": true,
-            "requires": {
-                "callsites": "^3.0.0"
-            }
-        },
         "path-is-absolute": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
             "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
-            "dev": true
-        },
-        "path-key": {
-            "version": "3.1.1",
-            "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
-            "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
-            "dev": true
-        },
-        "path-parse": {
-            "version": "1.0.7",
-            "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
-            "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
-            "dev": true
-        },
-        "path-type": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
-            "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
-            "dev": true
-        },
-        "picomatch": {
-            "version": "2.3.0",
-            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.0.tgz",
-            "integrity": "sha512-lY1Q/PiJGC2zOv/z391WOTD+Z02bCgsFfvxoXXf6h7kv9o+WmsmzYqrAwY63sNgOxE4xEdq0WyUnXfKeBrSvYw==",
             "dev": true
         },
         "pino": {
@@ -3876,12 +1716,6 @@
             "resolved": "https://registry.npmjs.org/pino-std-serializers/-/pino-std-serializers-3.2.0.tgz",
             "integrity": "sha512-EqX4pwDPrt3MuOAAUBMU0Tk5kR/YcCM5fNPEzgCO2zJ5HfX0vbiH9HbJglnyeQsN96Kznae6MWD47pZB5avTrg=="
         },
-        "prelude-ls": {
-            "version": "1.2.1",
-            "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
-            "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
-            "dev": true
-        },
         "process-nextick-args": {
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
@@ -3902,18 +1736,6 @@
                 "once": "^1.3.1"
             }
         },
-        "punycode": {
-            "version": "2.1.1",
-            "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
-            "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
-            "dev": true
-        },
-        "queue-microtask": {
-            "version": "1.2.3",
-            "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
-            "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
-            "dev": true
-        },
         "quick-format-unescaped": {
             "version": "4.0.3",
             "resolved": "https://registry.npmjs.org/quick-format-unescaped/-/quick-format-unescaped-4.0.3.tgz",
@@ -3929,47 +1751,10 @@
                 "util-deprecate": "^1.0.1"
             }
         },
-        "readdirp": {
-            "version": "3.6.0",
-            "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
-            "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
-            "dev": true,
-            "requires": {
-                "picomatch": "^2.2.1"
-            }
-        },
-        "regexpp": {
-            "version": "3.2.0",
-            "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-3.2.0.tgz",
-            "integrity": "sha512-pq2bWo9mVD43nbts2wGv17XLiNLya+GklZ8kaDLV2Z08gDCsGpnKn9BFMepvWuHCbyVvY7J5o5+BVvoQbmlJLg==",
-            "dev": true
-        },
         "require-directory": {
             "version": "2.1.1",
             "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
             "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
-            "dev": true
-        },
-        "resolve": {
-            "version": "1.20.0",
-            "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.20.0.tgz",
-            "integrity": "sha512-wENBPt4ySzg4ybFQW2TT1zMQucPK95HSh/nq2CFTZVOGut2+pQvSsgtda4d26YrYcr067wjbmzOG8byDPBX63A==",
-            "dev": true,
-            "requires": {
-                "is-core-module": "^2.2.0",
-                "path-parse": "^1.0.6"
-            }
-        },
-        "resolve-from": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
-            "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
-            "dev": true
-        },
-        "reusify": {
-            "version": "1.0.4",
-            "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.0.4.tgz",
-            "integrity": "sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==",
             "dev": true
         },
         "rfdc": {
@@ -3986,49 +1771,10 @@
                 "glob": "^7.1.3"
             }
         },
-        "run-parallel": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
-            "integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
-            "dev": true,
-            "requires": {
-                "queue-microtask": "^1.2.2"
-            }
-        },
         "safe-buffer": {
             "version": "5.2.1",
             "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
             "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
-        },
-        "semver": {
-            "version": "7.3.5",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
-            "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
-            "dev": true,
-            "requires": {
-                "lru-cache": "^6.0.0"
-            }
-        },
-        "shebang-command": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
-            "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
-            "dev": true,
-            "requires": {
-                "shebang-regex": "^3.0.0"
-            }
-        },
-        "shebang-regex": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
-            "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
-            "dev": true
-        },
-        "slash": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
-            "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
-            "dev": true
         },
         "sonic-boom": {
             "version": "2.6.0",
@@ -4036,22 +1782,6 @@
             "integrity": "sha512-6xYZFRmDEtxGqfOKcDQ4cPLrNa0SPEDI+wlzDAHowXE6YV42NeXqg9mP2KkiM8JVu3lHfZ2iQKYlGOz+kTpphg==",
             "requires": {
                 "atomic-sleep": "^1.0.0"
-            }
-        },
-        "source-map": {
-            "version": "0.6.1",
-            "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-            "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-            "dev": true
-        },
-        "source-map-support": {
-            "version": "0.5.21",
-            "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
-            "integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
-            "dev": true,
-            "requires": {
-                "buffer-from": "^1.0.0",
-                "source-map": "^0.6.0"
             }
         },
         "split2": {
@@ -4095,12 +1825,6 @@
                 "ansi-regex": "^5.0.1"
             }
         },
-        "strip-bom": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
-            "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
-            "dev": true
-        },
         "strip-json-comments": {
             "version": "3.1.1",
             "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
@@ -4113,12 +1837,6 @@
             "requires": {
                 "has-flag": "^4.0.0"
             }
-        },
-        "text-table": {
-            "version": "0.2.0",
-            "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
-            "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
-            "dev": true
         },
         "through2": {
             "version": "2.0.5",
@@ -4168,125 +1886,42 @@
                 }
             }
         },
-        "to-regex-range": {
-            "version": "5.0.1",
-            "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
-            "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+        "ts-node": {
+            "version": "10.9.2",
+            "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.2.tgz",
+            "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
             "dev": true,
             "requires": {
-                "is-number": "^7.0.0"
-            }
-        },
-        "tree-kill": {
-            "version": "1.2.2",
-            "resolved": "https://registry.npmjs.org/tree-kill/-/tree-kill-1.2.2.tgz",
-            "integrity": "sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==",
-            "dev": true
-        },
-        "ts-node-dev": {
-            "version": "1.1.8",
-            "resolved": "https://registry.npmjs.org/ts-node-dev/-/ts-node-dev-1.1.8.tgz",
-            "integrity": "sha512-Q/m3vEwzYwLZKmV6/0VlFxcZzVV/xcgOt+Tx/VjaaRHyiBcFlV0541yrT09QjzzCxlDZ34OzKjrFAynlmtflEg==",
-            "dev": true,
-            "requires": {
-                "chokidar": "^3.5.1",
-                "dynamic-dedupe": "^0.3.0",
-                "minimist": "^1.2.5",
-                "mkdirp": "^1.0.4",
-                "resolve": "^1.0.0",
-                "rimraf": "^2.6.1",
-                "source-map-support": "^0.5.12",
-                "tree-kill": "^1.2.2",
-                "ts-node": "^9.0.0",
-                "tsconfig": "^7.0.0"
-            },
-            "dependencies": {
-                "rimraf": {
-                    "version": "2.7.1",
-                    "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
-                    "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
-                    "dev": true,
-                    "requires": {
-                        "glob": "^7.1.3"
-                    }
-                },
-                "ts-node": {
-                    "version": "9.1.1",
-                    "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-9.1.1.tgz",
-                    "integrity": "sha512-hPlt7ZACERQGf03M253ytLY3dHbGNGrAq9qIHWUY9XHYl1z7wYngSr3OQ5xmui8o2AaxsONxIzjafLUiWBo1Fg==",
-                    "dev": true,
-                    "requires": {
-                        "arg": "^4.1.0",
-                        "create-require": "^1.1.0",
-                        "diff": "^4.0.1",
-                        "make-error": "^1.1.1",
-                        "source-map-support": "^0.5.17",
-                        "yn": "3.1.1"
-                    }
-                }
-            }
-        },
-        "tsconfig": {
-            "version": "7.0.0",
-            "resolved": "https://registry.npmjs.org/tsconfig/-/tsconfig-7.0.0.tgz",
-            "integrity": "sha512-vZXmzPrL+EmC4T/4rVlT2jNVMWCi/O4DIiSj3UHg1OE5kCKbk4mfrXc6dZksLgRM/TZlKnousKH9bbTazUWRRw==",
-            "dev": true,
-            "requires": {
-                "@types/strip-bom": "^3.0.0",
-                "@types/strip-json-comments": "0.0.30",
-                "strip-bom": "^3.0.0",
-                "strip-json-comments": "^2.0.0"
-            },
-            "dependencies": {
-                "strip-json-comments": {
-                    "version": "2.0.1",
-                    "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
-                    "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
-                    "dev": true
-                }
+                "@cspotcode/source-map-support": "^0.8.0",
+                "@tsconfig/node10": "^1.0.7",
+                "@tsconfig/node12": "^1.0.7",
+                "@tsconfig/node14": "^1.0.0",
+                "@tsconfig/node16": "^1.0.2",
+                "acorn": "^8.4.1",
+                "acorn-walk": "^8.1.1",
+                "arg": "^4.1.0",
+                "create-require": "^1.1.0",
+                "diff": "^4.0.1",
+                "make-error": "^1.1.1",
+                "v8-compile-cache-lib": "^3.0.1",
+                "yn": "3.1.1"
             }
         },
         "tslib": {
-            "version": "2.3.1",
-            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
-            "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
-        },
-        "tsutils": {
-            "version": "3.21.0",
-            "resolved": "https://registry.npmjs.org/tsutils/-/tsutils-3.21.0.tgz",
-            "integrity": "sha512-mHKK3iUXL+3UF6xL5k0PEhKRUBKPBCv/+RkEOpjRWxxx27KKRBmmA60A9pgOUvMi8GKhRMPEmjBRPzs2W7O1OA==",
-            "dev": true,
-            "requires": {
-                "tslib": "^1.8.1"
-            },
-            "dependencies": {
-                "tslib": {
-                    "version": "1.14.1",
-                    "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-                    "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
-                    "dev": true
-                }
-            }
-        },
-        "type-check": {
-            "version": "0.4.0",
-            "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
-            "integrity": "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==",
-            "dev": true,
-            "requires": {
-                "prelude-ls": "^1.2.1"
-            }
-        },
-        "type-fest": {
-            "version": "0.20.2",
-            "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
-            "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
-            "dev": true
+            "version": "2.8.1",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+            "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
         },
         "typescript": {
-            "version": "4.5.5",
-            "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.5.tgz",
-            "integrity": "sha512-TCTIul70LyWe6IJWT8QSYeA54WQe8EjQFU4wY52Fasj5UKx88LNYKCgBEHcOMOrFF1rKGbD8v/xcNWVUq9SymA==",
+            "version": "5.7.3",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.7.3.tgz",
+            "integrity": "sha512-84MVSjMEHP+FQRPy3pX9sTVV/INIex71s9TL2Gm5FG/WG1SqXeKyZ0k7/blY/4FdOzI12CBy1vGc4og/eus0fw==",
+            "dev": true
+        },
+        "undici-types": {
+            "version": "6.20.0",
+            "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.20.0.tgz",
+            "integrity": "sha512-Ny6QZ2Nju20vw1SRHe3d9jVu6gJ+4e3+MMpqu7pqE5HT6WsTSlce++GQmK5UXS8mzV8DSYHrQH+Xrf2jVcuKNg==",
             "dev": true
         },
         "untildify": {
@@ -4295,39 +1930,15 @@
             "integrity": "sha512-KK8xQ1mkzZeg9inewmFVDNkg3l5LUhoq9kN6iWYB/CC9YMG8HA+c1Q8HwDe6dEX7kErrEVNVBO3fWsVq5iDgtw==",
             "dev": true
         },
-        "uri-js": {
-            "version": "4.4.1",
-            "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
-            "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
-            "dev": true,
-            "requires": {
-                "punycode": "^2.1.0"
-            }
-        },
         "util-deprecate": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
             "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
         },
-        "v8-compile-cache": {
-            "version": "2.3.0",
-            "resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.3.0.tgz",
-            "integrity": "sha512-l8lCEmLcLYZh4nbunNZvQCJc5pv7+RCwa8q/LdUx8u7lsWvPDKmpodJAJNwkAhJC//dFY48KuIEmjtd4RViDrA==",
-            "dev": true
-        },
-        "which": {
-            "version": "2.0.2",
-            "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
-            "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
-            "dev": true,
-            "requires": {
-                "isexe": "^2.0.0"
-            }
-        },
-        "word-wrap": {
-            "version": "1.2.3",
-            "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
-            "integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==",
+        "v8-compile-cache-lib": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
+            "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
             "dev": true
         },
         "wrap-ansi": {
@@ -4356,12 +1967,6 @@
             "version": "5.0.8",
             "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
             "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
-            "dev": true
-        },
-        "yallist": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-            "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
             "dev": true
         },
         "yargs": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
                 "tslib": ">=2.8.1"
             },
             "devDependencies": {
+                "@biomejs/biome": "1.9.4",
                 "@types/node": "^22.10.7",
                 "@types/pino": "^6.3.12",
                 "copyfiles": "^2.4.1",
@@ -43,6 +44,170 @@
                 "@typescript-eslint/eslint-plugin": ">=5.14.0",
                 "@typescript-eslint/parser": ">=5.14.0",
                 "eslint": ">=8"
+            }
+        },
+        "node_modules/@biomejs/biome": {
+            "version": "1.9.4",
+            "resolved": "https://registry.npmjs.org/@biomejs/biome/-/biome-1.9.4.tgz",
+            "integrity": "sha512-1rkd7G70+o9KkTn5KLmDYXihGoTaIGO9PIIN2ZB7UJxFrWw04CZHPYiMRjYsaDvVV7hP1dYNRLxSANLaBFGpog==",
+            "dev": true,
+            "hasInstallScript": true,
+            "license": "MIT OR Apache-2.0",
+            "bin": {
+                "biome": "bin/biome"
+            },
+            "engines": {
+                "node": ">=14.21.3"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/biome"
+            },
+            "optionalDependencies": {
+                "@biomejs/cli-darwin-arm64": "1.9.4",
+                "@biomejs/cli-darwin-x64": "1.9.4",
+                "@biomejs/cli-linux-arm64": "1.9.4",
+                "@biomejs/cli-linux-arm64-musl": "1.9.4",
+                "@biomejs/cli-linux-x64": "1.9.4",
+                "@biomejs/cli-linux-x64-musl": "1.9.4",
+                "@biomejs/cli-win32-arm64": "1.9.4",
+                "@biomejs/cli-win32-x64": "1.9.4"
+            }
+        },
+        "node_modules/@biomejs/cli-darwin-arm64": {
+            "version": "1.9.4",
+            "resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-arm64/-/cli-darwin-arm64-1.9.4.tgz",
+            "integrity": "sha512-bFBsPWrNvkdKrNCYeAp+xo2HecOGPAy9WyNyB/jKnnedgzl4W4Hb9ZMzYNbf8dMCGmUdSavlYHiR01QaYR58cw==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT OR Apache-2.0",
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "engines": {
+                "node": ">=14.21.3"
+            }
+        },
+        "node_modules/@biomejs/cli-darwin-x64": {
+            "version": "1.9.4",
+            "resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-x64/-/cli-darwin-x64-1.9.4.tgz",
+            "integrity": "sha512-ngYBh/+bEedqkSevPVhLP4QfVPCpb+4BBe2p7Xs32dBgs7rh9nY2AIYUL6BgLw1JVXV8GlpKmb/hNiuIxfPfZg==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT OR Apache-2.0",
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "engines": {
+                "node": ">=14.21.3"
+            }
+        },
+        "node_modules/@biomejs/cli-linux-arm64": {
+            "version": "1.9.4",
+            "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64/-/cli-linux-arm64-1.9.4.tgz",
+            "integrity": "sha512-fJIW0+LYujdjUgJJuwesP4EjIBl/N/TcOX3IvIHJQNsAqvV2CHIogsmA94BPG6jZATS4Hi+xv4SkBBQSt1N4/g==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT OR Apache-2.0",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=14.21.3"
+            }
+        },
+        "node_modules/@biomejs/cli-linux-arm64-musl": {
+            "version": "1.9.4",
+            "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64-musl/-/cli-linux-arm64-musl-1.9.4.tgz",
+            "integrity": "sha512-v665Ct9WCRjGa8+kTr0CzApU0+XXtRgwmzIf1SeKSGAv+2scAlW6JR5PMFo6FzqqZ64Po79cKODKf3/AAmECqA==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT OR Apache-2.0",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=14.21.3"
+            }
+        },
+        "node_modules/@biomejs/cli-linux-x64": {
+            "version": "1.9.4",
+            "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64/-/cli-linux-x64-1.9.4.tgz",
+            "integrity": "sha512-lRCJv/Vi3Vlwmbd6K+oQ0KhLHMAysN8lXoCI7XeHlxaajk06u7G+UsFSO01NAs5iYuWKmVZjmiOzJ0OJmGsMwg==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT OR Apache-2.0",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=14.21.3"
+            }
+        },
+        "node_modules/@biomejs/cli-linux-x64-musl": {
+            "version": "1.9.4",
+            "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64-musl/-/cli-linux-x64-musl-1.9.4.tgz",
+            "integrity": "sha512-gEhi/jSBhZ2m6wjV530Yy8+fNqG8PAinM3oV7CyO+6c3CEh16Eizm21uHVsyVBEB6RIM8JHIl6AGYCv6Q6Q9Tg==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT OR Apache-2.0",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=14.21.3"
+            }
+        },
+        "node_modules/@biomejs/cli-win32-arm64": {
+            "version": "1.9.4",
+            "resolved": "https://registry.npmjs.org/@biomejs/cli-win32-arm64/-/cli-win32-arm64-1.9.4.tgz",
+            "integrity": "sha512-tlbhLk+WXZmgwoIKwHIHEBZUwxml7bRJgk0X2sPyNR3S93cdRq6XulAZRQJ17FYGGzWne0fgrXBKpl7l4M87Hg==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT OR Apache-2.0",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": ">=14.21.3"
+            }
+        },
+        "node_modules/@biomejs/cli-win32-x64": {
+            "version": "1.9.4",
+            "resolved": "https://registry.npmjs.org/@biomejs/cli-win32-x64/-/cli-win32-x64-1.9.4.tgz",
+            "integrity": "sha512-8Y5wMhVIPaWe6jw2H+KlEm4wP/f7EW3810ZLmDlrEEy5KvBsb9ECEfu/kMWD484ijfQ8+nIi0giMgu9g1UAuuA==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT OR Apache-2.0",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": ">=14.21.3"
             }
         },
         "node_modules/@cspotcode/source-map-support": {
@@ -1141,6 +1306,78 @@
         }
     },
     "dependencies": {
+        "@biomejs/biome": {
+            "version": "1.9.4",
+            "resolved": "https://registry.npmjs.org/@biomejs/biome/-/biome-1.9.4.tgz",
+            "integrity": "sha512-1rkd7G70+o9KkTn5KLmDYXihGoTaIGO9PIIN2ZB7UJxFrWw04CZHPYiMRjYsaDvVV7hP1dYNRLxSANLaBFGpog==",
+            "dev": true,
+            "requires": {
+                "@biomejs/cli-darwin-arm64": "1.9.4",
+                "@biomejs/cli-darwin-x64": "1.9.4",
+                "@biomejs/cli-linux-arm64": "1.9.4",
+                "@biomejs/cli-linux-arm64-musl": "1.9.4",
+                "@biomejs/cli-linux-x64": "1.9.4",
+                "@biomejs/cli-linux-x64-musl": "1.9.4",
+                "@biomejs/cli-win32-arm64": "1.9.4",
+                "@biomejs/cli-win32-x64": "1.9.4"
+            }
+        },
+        "@biomejs/cli-darwin-arm64": {
+            "version": "1.9.4",
+            "resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-arm64/-/cli-darwin-arm64-1.9.4.tgz",
+            "integrity": "sha512-bFBsPWrNvkdKrNCYeAp+xo2HecOGPAy9WyNyB/jKnnedgzl4W4Hb9ZMzYNbf8dMCGmUdSavlYHiR01QaYR58cw==",
+            "dev": true,
+            "optional": true
+        },
+        "@biomejs/cli-darwin-x64": {
+            "version": "1.9.4",
+            "resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-x64/-/cli-darwin-x64-1.9.4.tgz",
+            "integrity": "sha512-ngYBh/+bEedqkSevPVhLP4QfVPCpb+4BBe2p7Xs32dBgs7rh9nY2AIYUL6BgLw1JVXV8GlpKmb/hNiuIxfPfZg==",
+            "dev": true,
+            "optional": true
+        },
+        "@biomejs/cli-linux-arm64": {
+            "version": "1.9.4",
+            "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64/-/cli-linux-arm64-1.9.4.tgz",
+            "integrity": "sha512-fJIW0+LYujdjUgJJuwesP4EjIBl/N/TcOX3IvIHJQNsAqvV2CHIogsmA94BPG6jZATS4Hi+xv4SkBBQSt1N4/g==",
+            "dev": true,
+            "optional": true
+        },
+        "@biomejs/cli-linux-arm64-musl": {
+            "version": "1.9.4",
+            "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64-musl/-/cli-linux-arm64-musl-1.9.4.tgz",
+            "integrity": "sha512-v665Ct9WCRjGa8+kTr0CzApU0+XXtRgwmzIf1SeKSGAv+2scAlW6JR5PMFo6FzqqZ64Po79cKODKf3/AAmECqA==",
+            "dev": true,
+            "optional": true
+        },
+        "@biomejs/cli-linux-x64": {
+            "version": "1.9.4",
+            "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64/-/cli-linux-x64-1.9.4.tgz",
+            "integrity": "sha512-lRCJv/Vi3Vlwmbd6K+oQ0KhLHMAysN8lXoCI7XeHlxaajk06u7G+UsFSO01NAs5iYuWKmVZjmiOzJ0OJmGsMwg==",
+            "dev": true,
+            "optional": true
+        },
+        "@biomejs/cli-linux-x64-musl": {
+            "version": "1.9.4",
+            "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64-musl/-/cli-linux-x64-musl-1.9.4.tgz",
+            "integrity": "sha512-gEhi/jSBhZ2m6wjV530Yy8+fNqG8PAinM3oV7CyO+6c3CEh16Eizm21uHVsyVBEB6RIM8JHIl6AGYCv6Q6Q9Tg==",
+            "dev": true,
+            "optional": true
+        },
+        "@biomejs/cli-win32-arm64": {
+            "version": "1.9.4",
+            "resolved": "https://registry.npmjs.org/@biomejs/cli-win32-arm64/-/cli-win32-arm64-1.9.4.tgz",
+            "integrity": "sha512-tlbhLk+WXZmgwoIKwHIHEBZUwxml7bRJgk0X2sPyNR3S93cdRq6XulAZRQJ17FYGGzWne0fgrXBKpl7l4M87Hg==",
+            "dev": true,
+            "optional": true
+        },
+        "@biomejs/cli-win32-x64": {
+            "version": "1.9.4",
+            "resolved": "https://registry.npmjs.org/@biomejs/cli-win32-x64/-/cli-win32-x64-1.9.4.tgz",
+            "integrity": "sha512-8Y5wMhVIPaWe6jw2H+KlEm4wP/f7EW3810ZLmDlrEEy5KvBsb9ECEfu/kMWD484ijfQ8+nIi0giMgu9g1UAuuA==",
+            "dev": true,
+            "optional": true
+        },
         "@cspotcode/source-map-support": {
             "version": "0.8.1",
             "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",

--- a/package.json
+++ b/package.json
@@ -35,11 +35,7 @@
         "type": "git",
         "url": "git+ssh://git@github.com/runejs/common.git"
     },
-    "keywords": [
-        "runejs",
-        "runescape",
-        "typescript"
-    ],
+    "keywords": ["runejs", "runescape", "typescript"],
     "author": "Kikorono",
     "license": "GPL-3.0",
     "bugs": {

--- a/package.json
+++ b/package.json
@@ -19,6 +19,11 @@
     "scripts": {
         "build": "tsc",
         "start": "ts-node src/test.ts",
+        "lint": "biome lint",
+        "lint:fix": "biome lint --write",
+        "format": "biome format",
+        "format:fix": "biome format --write",
+        "fin": "npm run lint:fix && npm run format:fix",
         "copy-documents": "copyfiles package.json README.md .npmignore LICENSE lib",
         "package": "rimraf lib && npm i && npm run build && npm run copy-documents && cd lib && npm publish --dry-run",
         "publish:next": "npm run package && cd lib && npm publish -tag next",
@@ -53,6 +58,7 @@
         "tslib": ">=2.8.1"
     },
     "devDependencies": {
+        "@biomejs/biome": "1.9.4",
         "@types/node": "^22.10.7",
         "@types/pino": "^6.3.12",
         "copyfiles": "^2.4.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@runejs/common",
-    "version": "2.0.2-beta.2",
+    "version": "2.0.2-beta.3",
     "description": "Common logging, networking, compression, and other miscellaneous functionality for RuneJS.",
     "main": "./index.js",
     "types": "./index.d.ts",
@@ -19,8 +19,6 @@
     "scripts": {
         "build": "tsc",
         "start": "ts-node src/test.ts",
-        "lint": "eslint --ext .ts src",
-        "lint:fix": "eslint --ext .ts src --fix",
         "copy-documents": "copyfiles package.json README.md .npmignore LICENSE lib",
         "package": "rimraf lib && npm i && npm run build && npm run copy-documents && cd lib && npm publish --dry-run",
         "publish:next": "npm run package && cd lib && npm publish -tag next",
@@ -44,7 +42,7 @@
     },
     "homepage": "https://github.com/runejs/common#readme",
     "peerDependencies": {
-        "tslib": ">=2.3.0"
+        "tslib": ">=2.8.1"
     },
     "dependencies": {
         "compressjs": "^1.0.3",
@@ -52,26 +50,14 @@
         "pino": "^6.14.0",
         "pino-pretty": "^4.8.0",
         "sonic-boom": "^2.6.0",
-        "tslib": "^2.3.1"
+        "tslib": ">=2.8.1"
     },
     "devDependencies": {
-        "@runejs/eslint-config": "^1.1.0",
-        "@types/node": "^16.11.26",
+        "@types/node": "^22.10.7",
         "@types/pino": "^6.3.12",
-        "@typescript-eslint/eslint-plugin": "^5.14.0",
-        "@typescript-eslint/parser": "^5.14.0",
         "copyfiles": "^2.4.1",
-        "eslint": "^8.11.0",
         "rimraf": "^3.0.2",
-        "ts-node-dev": "^1.1.8",
-        "typescript": "^4.5.5"
-    },
-    "eslintConfig": {
-        "extends": [
-            "@runejs/eslint-config"
-        ],
-        "parserOptions": {
-            "project": "./tsconfig.json"
-        }
+        "ts-node": "^10.9.2",
+        "typescript": "^5.7.3"
     }
 }

--- a/src/buffer/byte-buffer.ts
+++ b/src/buffer/byte-buffer.ts
@@ -2,66 +2,101 @@ import { Buffer } from 'buffer';
 import { logger } from '../logger';
 
 export type DataType =
-    'BYTE' | 'SHORT' | 'SMART_SHORT' | 'SMART_INT' | 'INT24' | 'INT' | 'LONG' | 'STRING' |
-    'byte' | 'short' | 'smart_short' | 'smart_int' | 'int24' | 'int' | 'long' | 'string';
+    | 'BYTE'
+    | 'SHORT'
+    | 'SMART_SHORT'
+    | 'SMART_INT'
+    | 'INT24'
+    | 'INT'
+    | 'LONG'
+    | 'STRING'
+    | 'byte'
+    | 'short'
+    | 'smart_short'
+    | 'smart_int'
+    | 'int24'
+    | 'int'
+    | 'long'
+    | 'string';
 
 export type Endianness =
-    'LITTLE_ENDIAN' | 'BIG_ENDIAN' | 'MIDDLE_ENDIAN_1' | 'MIDDLE_ENDIAN_2' |
-    'little_endian' | 'big_endian' | 'middle_endian_1' | 'middle_endian_2' |
-    'le' | 'LE' | 'be' | 'BE' | 'me1' | 'ME1' | 'me2' | 'ME2';
+    | 'LITTLE_ENDIAN'
+    | 'BIG_ENDIAN'
+    | 'MIDDLE_ENDIAN_1'
+    | 'MIDDLE_ENDIAN_2'
+    | 'little_endian'
+    | 'big_endian'
+    | 'middle_endian_1'
+    | 'middle_endian_2'
+    | 'le'
+    | 'LE'
+    | 'be'
+    | 'BE'
+    | 'me1'
+    | 'ME1'
+    | 'me2'
+    | 'ME2';
 
 export type Signedness =
-    'SIGNED' | 'UNSIGNED' |
-    'signed' | 'unsigned' |
-    's' | 'u' | 'S' | 'U';
-
+    | 'SIGNED'
+    | 'UNSIGNED'
+    | 'signed'
+    | 'unsigned'
+    | 's'
+    | 'u'
+    | 'S'
+    | 'U';
 
 export const MAX_SIGNED_LENGTHS = {
-    'byte': 127,
-    'short': 32767,
-    'smart_short': -1,
-    'smart_int': -1,
-    'int24': 8388607,
-    'int': 2147483647,
-    'long': BigInt('9223372036854775807')
+    byte: 127,
+    short: 32767,
+    smart_short: -1,
+    smart_int: -1,
+    int24: 8388607,
+    int: 2147483647,
+    long: BigInt('9223372036854775807'),
 };
 
 export const BYTE_LENGTH = {
-    'byte': 1,
-    'short': 2,
-    'smart': -1,
-    'int24': 3,
-    'int': 4,
-    'long': 8
+    byte: 1,
+    short: 2,
+    smart: -1,
+    int24: 3,
+    int: 4,
+    long: 8,
 };
 
 export const BIT_LENGTH = {
-    'byte': 8,
-    'short': 16,
-    'smart': -1,
-    'int24': 24,
-    'int': 32,
-    'long': 64
+    byte: 8,
+    short: 16,
+    smart: -1,
+    int24: 24,
+    int: 32,
+    long: 64,
 };
 
 export const ENDIAN_SUFFIX = {
-    'little_endian': 'LE',
-    'big_endian': 'BE',
-    'middle_endian_1': 'ME1',
-    'middle_endian_2': 'ME2'
+    little_endian: 'LE',
+    big_endian: 'BE',
+    middle_endian_1: 'ME1',
+    middle_endian_2: 'ME2',
 };
 
 const BIT_MASKS: number[] = [];
 
-for(let i = 0; i < 32; i++) {
+for (let i = 0; i < 32; i++) {
     BIT_MASKS.push((1 << i) - 1);
 }
 
 export class ByteBuffer extends Uint8Array {
-
     public readInt8: (offset: number) => number;
     public readUInt8: (offset: number) => number;
-    public copy: (targetBuffer: Uint8Array | ByteBuffer, targetStart?: number, sourceStart?: number, sourceEnd?: number) => number;
+    public copy: (
+        targetBuffer: Uint8Array | ByteBuffer,
+        targetStart?: number,
+        sourceStart?: number,
+        sourceEnd?: number,
+    ) => number;
 
     private _writerIndex: number = 0;
     private _readerIndex: number = 0;
@@ -72,11 +107,15 @@ export class ByteBuffer extends Uint8Array {
     }
 
     public static getSignage(signed: Signedness): Signedness {
-        return (signed.length === 1 ? signed : signed.charAt(0)).toUpperCase() as Signedness;
+        return (
+            signed.length === 1 ? signed : signed.charAt(0)
+        ).toUpperCase() as Signedness;
     }
 
     public static getEndianness(endian: Endianness): Endianness {
-        return (endian.length < 4 ? endian : ENDIAN_SUFFIX[endian.toLowerCase()]).toUpperCase() as Endianness;
+        return (
+            endian.length < 4 ? endian : ENDIAN_SUFFIX[endian.toLowerCase()]
+        ).toUpperCase() as Endianness;
     }
 
     public static fromNodeBuffer(buffer: Buffer): ByteBuffer {
@@ -93,21 +132,37 @@ export class ByteBuffer extends Uint8Array {
 
     public get(): number;
     public get(type: Extract<DataType, 'string' | 'STRING'>): string;
-    public get(type: Extract<DataType, 'long' | 'LONG'>, signed?: Signedness, endian?: Endianness): bigint;
-    public get(type: Exclude<DataType, 'string' | 'STRING' | 'long' | 'LONG'>, signed?: Signedness, endian?: Endianness): number;
-    public get(type?: DataType, signed?: Signedness, endian?: Endianness): number | bigint | string;
-    public get(type: DataType = 'byte', signed: Signedness = 'signed', endian: Endianness = 'be'): number | bigint | string {
+    public get(
+        type: Extract<DataType, 'long' | 'LONG'>,
+        signed?: Signedness,
+        endian?: Endianness,
+    ): bigint;
+    public get(
+        type: Exclude<DataType, 'string' | 'STRING' | 'long' | 'LONG'>,
+        signed?: Signedness,
+        endian?: Endianness,
+    ): number;
+    public get(
+        type?: DataType,
+        signed?: Signedness,
+        endian?: Endianness,
+    ): number | bigint | string;
+    public get(
+        type: DataType = 'byte',
+        signed: Signedness = 'signed',
+        endian: Endianness = 'be',
+    ): number | bigint | string {
         type = ByteBuffer.getType(type);
         signed = ByteBuffer.getSignage(signed);
         endian = ByteBuffer.getEndianness(endian);
 
         const readerIndex = this._readerIndex;
 
-        if(type === 'smart_short') {
+        if (type === 'smart_short') {
             return this.getSmartShort(readerIndex, signed);
-        } else if(type === 'smart_int') {
+        } else if (type === 'smart_int') {
             return this.getSmartInt(readerIndex, signed);
-        } else if(type === 'string') {
+        } else if (type === 'string') {
             return this.getString();
         } else {
             const size = BYTE_LENGTH[type];
@@ -120,12 +175,12 @@ export class ByteBuffer extends Uint8Array {
             const methodName = `read${smol}${signedChar}Int${bitLength}${suffix}`;
 
             try {
-                if(type === 'long') {
+                if (type === 'long') {
                     return this[methodName](readerIndex) as bigint;
                 } else {
                     return this[methodName](readerIndex) as number;
                 }
-            } catch(error) {
+            } catch (error) {
                 logger.error(`Error reading ${methodName}:`, error);
                 return null;
             }
@@ -133,21 +188,37 @@ export class ByteBuffer extends Uint8Array {
     }
 
     public put(value: number): ByteBuffer;
-    public put(value: string, type: Extract<DataType, 'string' | 'STRING'>): ByteBuffer;
-    public put(value: bigint, type: Extract<DataType, 'long' | 'LONG'>): ByteBuffer;
-    public put(value: number | bigint, type?: DataType, endian?: Endianness): ByteBuffer
-    public put(value: number | bigint | string, type: DataType = 'byte', endian: Endianness = 'be'): ByteBuffer {
+    public put(
+        value: string,
+        type: Extract<DataType, 'string' | 'STRING'>,
+    ): ByteBuffer;
+    public put(
+        value: bigint,
+        type: Extract<DataType, 'long' | 'LONG'>,
+    ): ByteBuffer;
+    public put(
+        value: number | bigint,
+        type?: DataType,
+        endian?: Endianness,
+    ): ByteBuffer;
+    public put(
+        value: number | bigint | string,
+        type: DataType = 'byte',
+        endian: Endianness = 'be',
+    ): ByteBuffer {
         const writerIndex = this._writerIndex;
 
         type = ByteBuffer.getType(type);
         endian = ByteBuffer.getEndianness(endian);
 
-        if(type === 'smart_short') {
+        if (type === 'smart_short') {
             return this.putSmartShort(value as number);
-        } else if(type === 'smart_int') {
+        } else if (type === 'smart_int') {
             return this.putSmartInt(value as number);
-        } else if(type === 'string' || typeof value === 'string') {
-            return this.putString(typeof value !== 'string' ? String(value) : value);
+        } else if (type === 'string' || typeof value === 'string') {
+            return this.putString(
+                typeof value !== 'string' ? String(value) : value,
+            );
         } else {
             const maxSignedLength = MAX_SIGNED_LENGTHS[type];
             const size = BYTE_LENGTH[type];
@@ -161,7 +232,7 @@ export class ByteBuffer extends Uint8Array {
 
             try {
                 return this[methodName](value, writerIndex);
-            } catch(error) {
+            } catch (error) {
                 logger.error(`Error writing ${methodName}:`, error);
                 return null;
             }
@@ -169,11 +240,34 @@ export class ByteBuffer extends Uint8Array {
     }
 
     public at(index: number): number;
-    public at(index: number, type: Extract<DataType, 'string' | 'STRING'>): string;
-    public at(index: number, type: Extract<DataType, 'long' | 'LONG'>, signed?: Signedness, endian?: Endianness): bigint;
-    public at(index: number, type: Exclude<DataType, 'string' | 'STRING' | 'long' | 'LONG'>, signed?: Signedness, endian?: Endianness): number;
-    public at(index: number, type?: DataType, signed?: Signedness, endian?: Endianness): number | bigint | string;
-    public at(index: number, type: DataType = 'byte', signed: Signedness = 'signed', endian: Endianness = 'be'): number | bigint | string {
+    public at(
+        index: number,
+        type: Extract<DataType, 'string' | 'STRING'>,
+    ): string;
+    public at(
+        index: number,
+        type: Extract<DataType, 'long' | 'LONG'>,
+        signed?: Signedness,
+        endian?: Endianness,
+    ): bigint;
+    public at(
+        index: number,
+        type: Exclude<DataType, 'string' | 'STRING' | 'long' | 'LONG'>,
+        signed?: Signedness,
+        endian?: Endianness,
+    ): number;
+    public at(
+        index: number,
+        type?: DataType,
+        signed?: Signedness,
+        endian?: Endianness,
+    ): number | bigint | string;
+    public at(
+        index: number,
+        type: DataType = 'byte',
+        signed: Signedness = 'signed',
+        endian: Endianness = 'be',
+    ): number | bigint | string {
         const readerIndex = this.readerIndex;
         this.readerIndex = index;
 
@@ -189,9 +283,18 @@ export class ByteBuffer extends Uint8Array {
         return new ByteBuffer(this.slice(position, position + length));
     }
 
-    public putBytes(from: ByteBuffer | Buffer, fromStart?: number, fromEnd?: number): ByteBuffer {
-        from.copy(this, this.writerIndex, fromStart || 0, fromEnd || from.length);
-        this.writerIndex = (this.writerIndex + from.length);
+    public putBytes(
+        from: ByteBuffer | Buffer,
+        fromStart?: number,
+        fromEnd?: number,
+    ): ByteBuffer {
+        from.copy(
+            this,
+            this.writerIndex,
+            fromStart || 0,
+            fromEnd || from.length,
+        );
+        this.writerIndex = this.writerIndex + from.length;
         return this;
     }
 
@@ -206,18 +309,20 @@ export class ByteBuffer extends Uint8Array {
 
         this.bitIndex += bitCount;
 
-        for(; bitCount > bitOffset; bitOffset = 8) {
+        for (; bitCount > bitOffset; bitOffset = 8) {
             this[byteIndex] &= ~BIT_MASKS[bitOffset];
-            this[byteIndex++] |= (value >> (bitCount - bitOffset)) & BIT_MASKS[bitOffset];
+            this[byteIndex++] |=
+                (value >> (bitCount - bitOffset)) & BIT_MASKS[bitOffset];
             bitCount -= bitOffset;
         }
 
-        if(bitCount == bitOffset) {
+        if (bitCount == bitOffset) {
             this[byteIndex] &= ~BIT_MASKS[bitOffset];
             this[byteIndex] |= value & BIT_MASKS[bitOffset];
         } else {
             this[byteIndex] &= ~(BIT_MASKS[bitCount] << (bitOffset - bitCount));
-            this[byteIndex] |= (value & BIT_MASKS[bitCount]) << (bitOffset - bitCount);
+            this[byteIndex] |=
+                (value & BIT_MASKS[bitCount]) << (bitOffset - bitCount);
         }
 
         return this;
@@ -248,7 +353,7 @@ export class ByteBuffer extends Uint8Array {
         const bytes: number[] = [];
         let b: number;
 
-        while((b = this.get('byte')) !== terminatingChar) {
+        while ((b = this.get('byte')) !== terminatingChar) {
             bytes.push(b);
         }
 
@@ -259,7 +364,7 @@ export class ByteBuffer extends Uint8Array {
         const encoder = new TextEncoder();
         const bytes = encoder.encode(value);
 
-        for(const byte of bytes) {
+        for (const byte of bytes) {
             this.put(byte);
         }
 
@@ -268,7 +373,7 @@ export class ByteBuffer extends Uint8Array {
     }
 
     public putSmartShort(value: number): ByteBuffer {
-        if(value >= 128) {
+        if (value >= 128) {
             this.put(value, 'short');
         } else {
             this.put(value, 'byte');
@@ -276,20 +381,25 @@ export class ByteBuffer extends Uint8Array {
         return this;
     }
 
-    public getSmartShort(offset: number, signed: Signedness = 'signed'): number {
+    public getSmartShort(
+        offset: number,
+        signed: Signedness = 'signed',
+    ): number {
         const peek = this[offset];
 
         const signedString = ByteBuffer.getSignage(signed);
 
-        if(peek < 128) {
+        if (peek < 128) {
             return this.get('byte', 'u') - (signedString === 'S' ? 0 : 64);
         } else {
-            return this.get('short', 'u') - (signedString === 'S' ? 32768 : 49152);
+            return (
+                this.get('short', 'u') - (signedString === 'S' ? 32768 : 49152)
+            );
         }
     }
 
     public putSmartInt(value: number): ByteBuffer {
-        if(value >= 128) {
+        if (value >= 128) {
             this.put(value, 'int');
         } else {
             this.put(value, 'short');
@@ -302,10 +412,12 @@ export class ByteBuffer extends Uint8Array {
 
         const signedString = ByteBuffer.getSignage(signed);
 
-        if(peek < 128) {
+        if (peek < 128) {
             return this.get('short', 'u') - (signedString === 'S' ? 0 : 64);
         } else {
-            return this.get('int', 'u') - (signedString === 'S' ? 32768 : 49152);
+            return (
+                this.get('int', 'u') - (signedString === 'S' ? 32768 : 49152)
+            );
         }
     }
 
@@ -317,43 +429,55 @@ export class ByteBuffer extends Uint8Array {
     }
 
     public readUInt24BE(offset: number): number {
-        return ((this[offset] & 0xff) << 16) + ((this[offset + 1] & 0xff) << 8) + (this[offset + 2] & 0xff);
+        return (
+            ((this[offset] & 0xff) << 16) +
+            ((this[offset + 1] & 0xff) << 8) +
+            (this[offset + 2] & 0xff)
+        );
     }
 
     public readInt24BE(offset: number): number {
-        return ((this[offset]) << 16) + ((this[offset + 1]) << 8) + (this[offset + 2]);
+        return (
+            (this[offset] << 16) + (this[offset + 1] << 8) + this[offset + 2]
+        );
     }
 
     public readUInt24LE(offset: number): number {
-        return ((this[offset + 2] & 0xff) << 16) + ((this[offset + 1] & 0xff) << 8) + (this[offset] & 0xff);
+        return (
+            ((this[offset + 2] & 0xff) << 16) +
+            ((this[offset + 1] & 0xff) << 8) +
+            (this[offset] & 0xff)
+        );
     }
 
     public readInt24LE(offset: number): number {
-        return ((this[offset + 2]) << 16) + ((this[offset + 1]) << 8) + (this[offset]);
+        return (
+            (this[offset + 2] << 16) + (this[offset + 1] << 8) + this[offset]
+        );
     }
 
     public writeUInt24BE(value: number, offset: number): void {
-        this[offset] = ((value & 0xff) >> 16);
-        this[offset + 1] = ((value & 0xff) >> 8);
-        this[offset + 2] = (value & 0xff);
+        this[offset] = (value & 0xff) >> 16;
+        this[offset + 1] = (value & 0xff) >> 8;
+        this[offset + 2] = value & 0xff;
     }
 
     public writeInt24BE(value: number, offset: number): void {
-        this[offset] = (value >> 16);
-        this[offset + 1] = (value >> 8);
-        this[offset + 2] = (value);
+        this[offset] = value >> 16;
+        this[offset + 1] = value >> 8;
+        this[offset + 2] = value;
     }
 
     public writeUInt24LE(value: number, offset: number): void {
-        this[offset + 2] = ((value & 0xff) >> 16);
-        this[offset + 1] = ((value & 0xff) >> 8);
-        this[offset] = (value & 0xff);
+        this[offset + 2] = (value & 0xff) >> 16;
+        this[offset + 1] = (value & 0xff) >> 8;
+        this[offset] = value & 0xff;
     }
 
     public writeInt24LE(value: number, offset: number): void {
-        this[offset + 2] = (value >> 16);
-        this[offset + 1] = (value >> 8);
-        this[offset] = (value);
+        this[offset + 2] = value >> 16;
+        this[offset + 1] = value >> 8;
+        this[offset] = value;
     }
 
     public get writerIndex(): number {

--- a/src/color/color.ts
+++ b/src/color/color.ts
@@ -11,7 +11,7 @@ export abstract class Color<T> {
     public readonly format: ColorFormat;
     public alpha: number;
 
-    public constructor(format: ColorFormat, alpha: number = 255) {
+    public constructor(format: ColorFormat, alpha = 255) {
         if (!format) {
             throw new Error(`Invalid color format ${format}.`);
         }
@@ -35,7 +35,7 @@ export abstract class Color<T> {
     abstract toString(): string;
 
     public values(colorValues: Partial<T>): T {
-        if (colorValues['alpha']) {
+        if ('alpha' in colorValues && colorValues.alpha) {
             return { ...colorValues, format: this.format } as unknown as T;
         }
         return {

--- a/src/color/color.ts
+++ b/src/color/color.ts
@@ -1,25 +1,24 @@
 export type ColorFormat = 'rgb' | 'hsl' | 'hsv' | 'hcl' | 'lab';
 
-
 export const constants = {
     black_hue: 0,
     white_hue: 0,
     black_saturation: 0,
-    white_saturation: 0
+    white_saturation: 0,
 };
 
-
 export abstract class Color<T> {
-
     public readonly format: ColorFormat;
     public alpha: number;
 
     public constructor(format: ColorFormat, alpha: number = 255) {
-        if(!format) {
+        if (!format) {
             throw new Error(`Invalid color format ${format}.`);
         }
-        if(alpha < 0 || alpha > 255) {
-            throw new Error(`Alpha value must be between 0-255, received ${alpha}.`);
+        if (alpha < 0 || alpha > 255) {
+            throw new Error(
+                `Alpha value must be between 0-255, received ${alpha}.`,
+            );
         }
 
         this.format = format;
@@ -36,10 +35,13 @@ export abstract class Color<T> {
     abstract toString(): string;
 
     public values(colorValues: Partial<T>): T {
-        if(colorValues['alpha']) {
+        if (colorValues['alpha']) {
             return { ...colorValues, format: this.format } as unknown as T;
         }
-        return { ...colorValues, format: this.format, alpha: this.alpha } as unknown as T;
+        return {
+            ...colorValues,
+            format: this.format,
+            alpha: this.alpha,
+        } as unknown as T;
     }
-
 }

--- a/src/color/hcl.ts
+++ b/src/color/hcl.ts
@@ -57,8 +57,11 @@ export class HCL extends HCLValues {
             this.rgb = typeof arg0 === 'number' ? new RGB(arg0) : arg0;
             const { h, c, l } = HCL.fromRgb(this.rgb);
             hue = h;
+            // biome-ignore lint/style/noParameterAssign: Legacy
             chroma = c;
+            // biome-ignore lint/style/noParameterAssign: Legacy
             luminance = l;
+            // biome-ignore lint/style/noParameterAssign: Legacy
             alpha = this.rgb.alpha;
         }
 
@@ -85,7 +88,8 @@ export class HCL extends HCLValues {
 
         const h = rgb.calculateHue();
 
-        let c, l: number;
+        let c: number;
+        let l: number;
 
         if (max === 0) {
             c = 0;

--- a/src/color/hcl.ts
+++ b/src/color/hcl.ts
@@ -2,23 +2,18 @@ import { Color, constants } from './color';
 import { RGB } from './rgb';
 import { fixedFloor, pad } from '../util';
 
-
 export abstract class HCLValues extends Color<HCLValues> {
-
     public h: number;
     public c: number;
     public l: number;
 
     abstract toString();
-
 }
-
 
 /**
  * A color within the HCL color space.
  */
 export class HCL extends HCLValues {
-
     /**
      * The RGB equivalent of this color, if provided during instantiation.
      */
@@ -43,12 +38,22 @@ export class HCL extends HCLValues {
      * @param luminance The color's luminance value.
      * @param alpha [optional] The alpha value of the color, from 0-255. Defaults to 255, fully opaque.
      */
-    public constructor(hue: number, chroma: number, luminance: number, alpha?: number);
+    public constructor(
+        hue: number,
+        chroma: number,
+        luminance: number,
+        alpha?: number,
+    );
 
-    public constructor(arg0: number | RGB, chroma?: number, luminance?: number, alpha = 255) {
+    public constructor(
+        arg0: number | RGB,
+        chroma?: number,
+        luminance?: number,
+        alpha = 255,
+    ) {
         super('hcl');
         let hue = arg0;
-        if(chroma === undefined && luminance === undefined) {
+        if (chroma === undefined && luminance === undefined) {
             this.rgb = typeof arg0 === 'number' ? new RGB(arg0) : arg0;
             const { h, c, l } = HCL.fromRgb(this.rgb);
             hue = h;
@@ -68,7 +73,7 @@ export class HCL extends HCLValues {
      * @param rgb The RGB(A) color to convert into HCL.
      */
     public static fromRgb(rgb: RGB): Partial<HCLValues> {
-        if(rgb.isPureBlack) {
+        if (rgb.isPureBlack) {
             return { h: constants.black_hue, c: 0, l: 0 };
         }
 
@@ -82,23 +87,23 @@ export class HCL extends HCLValues {
 
         let c, l: number;
 
-        if(max === 0) {
+        if (max === 0) {
             c = 0;
             l = 0;
         } else {
-            const alpha = (min / max) / 100;
+            const alpha = min / max / 100;
             const q = Math.exp(alpha * 3);
             const rg = r - g;
             const gb = g - b;
             const br = b - r;
-            l = ((q * max) + ((1 - q) * min)) / 2;
-            c = q * (Math.abs(rg) + Math.abs(gb) + Math.abs(br)) / 3;
+            l = (q * max + (1 - q) * min) / 2;
+            c = (q * (Math.abs(rg) + Math.abs(gb) + Math.abs(br))) / 3;
         }
 
         return Color.values<HCLValues>({
             h,
             c: fixedFloor(c * 100, 0),
-            l: fixedFloor(l * 100, 0)
+            l: fixedFloor(l * 100, 0),
         });
     }
 
@@ -111,8 +116,9 @@ export class HCL extends HCLValues {
     }
 
     public toString(): string {
-        return `HCL(A) ( ${pad(this.h, 3)}, ${pad(this.c, 3)}%, ` +
-            `${pad(this.l, 3)}%, ${pad(this.alpha, 3)} )`;
+        return (
+            `HCL(A) ( ${pad(this.h, 3)}, ${pad(this.c, 3)}%, ` +
+            `${pad(this.l, 3)}%, ${pad(this.alpha, 3)} )`
+        );
     }
-
 }

--- a/src/color/hsl.ts
+++ b/src/color/hsl.ts
@@ -2,23 +2,18 @@ import { Color, constants } from './color';
 import { RGB } from './rgb';
 import { pad, fixedFloor } from '../util';
 
-
 export abstract class HSLValues extends Color<HSLValues> {
-
     public h: number;
     public s: number;
     public l: number;
 
     abstract toString();
-
 }
-
 
 /**
  * A color within the HSL color space.
  */
 export class HSL extends HSLValues {
-
     /**
      * The RGB equivalent of this color, if provided during instantiation.
      */
@@ -43,12 +38,22 @@ export class HSL extends HSLValues {
      * @param lightness The color's lightness value.
      * @param alpha [optional] The alpha value of the color, from 0-255. Defaults to 255, fully opaque.
      */
-    public constructor(hue: number, saturation: number, lightness: number, alpha?: number);
+    public constructor(
+        hue: number,
+        saturation: number,
+        lightness: number,
+        alpha?: number,
+    );
 
-    public constructor(arg0: number | RGB, saturation?: number, lightness?: number, alpha = 255) {
+    public constructor(
+        arg0: number | RGB,
+        saturation?: number,
+        lightness?: number,
+        alpha = 255,
+    ) {
         super('hsl');
         let hue = arg0;
-        if(saturation === undefined && lightness === undefined) {
+        if (saturation === undefined && lightness === undefined) {
             this.rgb = typeof arg0 === 'number' ? new RGB(arg0) : arg0;
             const { h, s, l } = HSL.fromRgb(this.rgb);
             hue = h;
@@ -68,8 +73,12 @@ export class HSL extends HSLValues {
      * @param rgb The RGB(A) color to convert into HSL.
      */
     public static fromRgb(rgb: RGB): Partial<HSLValues> {
-        if(rgb.isPureBlack) {
-            return { h: constants.black_hue, s: constants.black_saturation, l: 0 };
+        if (rgb.isPureBlack) {
+            return {
+                h: constants.black_hue,
+                s: constants.black_saturation,
+                l: 0,
+            };
         }
 
         let { max, min } = rgb;
@@ -81,7 +90,7 @@ export class HSL extends HSLValues {
         const s = rgb.calculateSaturation();
         const l = fixedFloor(((max + min) / 2) * 100, 0);
 
-        if(h === 0 && s === 0 && l > 0) {
+        if (h === 0 && s === 0 && l > 0) {
             // gray/white
             // h = 60; ???
         }
@@ -98,8 +107,9 @@ export class HSL extends HSLValues {
     }
 
     public toString(): string {
-        return `HSL(A) ( ${pad(this.h, 3)}, ${pad(this.s, 3)}%, ` +
-            `${pad(this.l, 3)}%, ${pad(this.alpha, 3)} )`;
+        return (
+            `HSL(A) ( ${pad(this.h, 3)}, ${pad(this.s, 3)}%, ` +
+            `${pad(this.l, 3)}%, ${pad(this.alpha, 3)} )`
+        );
     }
-
 }

--- a/src/color/hsl.ts
+++ b/src/color/hsl.ts
@@ -57,8 +57,11 @@ export class HSL extends HSLValues {
             this.rgb = typeof arg0 === 'number' ? new RGB(arg0) : arg0;
             const { h, s, l } = HSL.fromRgb(this.rgb);
             hue = h;
+            // biome-ignore lint/style/noParameterAssign: Legacy
             saturation = s;
+            // biome-ignore lint/style/noParameterAssign: Legacy
             lightness = l;
+            // biome-ignore lint/style/noParameterAssign: Legacy
             alpha = this.rgb.alpha;
         }
 

--- a/src/color/hsv.ts
+++ b/src/color/hsv.ts
@@ -2,23 +2,18 @@ import { Color, constants } from './color';
 import { RGB } from './rgb';
 import { fixedFloor, pad } from '../util';
 
-
 export abstract class HSVValues extends Color<HSVValues> {
-
     public h: number;
     public s: number;
     public v: number;
 
     abstract toString();
-
 }
-
 
 /**
  * A color within the HSV color space.
  */
 export class HSV extends HSVValues {
-
     /**
      * The RGB equivalent of this color, if provided during instantiation.
      */
@@ -43,12 +38,22 @@ export class HSV extends HSVValues {
      * @param value The color's brightness value.
      * @param alpha [optional] The alpha value of the color, from 0-255. Defaults to 255, fully opaque.
      */
-    public constructor(hue: number, saturation: number, value: number, alpha?: number);
+    public constructor(
+        hue: number,
+        saturation: number,
+        value: number,
+        alpha?: number,
+    );
 
-    public constructor(arg0: number | RGB, saturation?: number, value?: number, alpha = 255) {
+    public constructor(
+        arg0: number | RGB,
+        saturation?: number,
+        value?: number,
+        alpha = 255,
+    ) {
         super('hsv');
         let hue = arg0;
-        if(saturation === undefined && value === undefined) {
+        if (saturation === undefined && value === undefined) {
             this.rgb = typeof arg0 === 'number' ? new RGB(arg0) : arg0;
             const { h, s, v } = HSV.fromRgb(this.rgb);
             hue = h;
@@ -68,8 +73,12 @@ export class HSV extends HSVValues {
      * @param rgb The RGB(A) color to convert into HSV.
      */
     public static fromRgb(rgb: RGB): Partial<HSVValues> {
-        if(rgb.isPureBlack) {
-            return { h: constants.black_hue, s: constants.black_saturation, v: 0 };
+        if (rgb.isPureBlack) {
+            return {
+                h: constants.black_hue,
+                s: constants.black_saturation,
+                v: 0,
+            };
         }
 
         let { max } = rgb;
@@ -80,7 +89,7 @@ export class HSV extends HSVValues {
         const s = rgb.calculateSaturation();
         const v = fixedFloor(max * 100, 0);
 
-        if(h === 0 && s === 0 && v > 0) {
+        if (h === 0 && s === 0 && v > 0) {
             // gray/white
             // h = 60; ???
         }
@@ -97,8 +106,9 @@ export class HSV extends HSVValues {
     }
 
     public toString(): string {
-        return `HSV(A) ( ${pad(this.h, 3)}, ${pad(this.s, 3)}%, ` +
-            `${pad(this.v, 3)}%, ${pad(this.alpha, 3)} )`;
+        return (
+            `HSV(A) ( ${pad(this.h, 3)}, ${pad(this.s, 3)}%, ` +
+            `${pad(this.v, 3)}%, ${pad(this.alpha, 3)} )`
+        );
     }
-
 }

--- a/src/color/hsv.ts
+++ b/src/color/hsv.ts
@@ -57,8 +57,11 @@ export class HSV extends HSVValues {
             this.rgb = typeof arg0 === 'number' ? new RGB(arg0) : arg0;
             const { h, s, v } = HSV.fromRgb(this.rgb);
             hue = h;
+            // biome-ignore lint/style/noParameterAssign: Legacy
             saturation = s;
+            // biome-ignore lint/style/noParameterAssign: Legacy
             value = v;
+            // biome-ignore lint/style/noParameterAssign: Legacy
             alpha = this.rgb.alpha;
         }
 

--- a/src/color/lab.ts
+++ b/src/color/lab.ts
@@ -2,23 +2,18 @@ import { Color } from './color';
 import { RGB } from './rgb';
 import { fixedFloor, pad } from '../util';
 
-
 export abstract class LABValues extends Color<LABValues> {
-
     public l: number;
     public a: number;
     public b: number;
 
     abstract toString();
-
 }
-
 
 /**
  * A color within the LAB color space.
  */
 export class LAB extends LABValues {
-
     /**
      * The RGB equivalent of this color, if provided during instantiation.
      */
@@ -45,10 +40,15 @@ export class LAB extends LABValues {
      */
     public constructor(lightness: number, a: number, b: number, alpha?: number);
 
-    public constructor(arg0: number | RGB, a?: number, b?: number, alpha = 255) {
+    public constructor(
+        arg0: number | RGB,
+        a?: number,
+        b?: number,
+        alpha = 255,
+    ) {
         super('hcl');
         let lightness = arg0;
-        if(a === undefined && b === undefined) {
+        if (a === undefined && b === undefined) {
             this.rgb = typeof arg0 === 'number' ? new RGB(arg0) : arg0;
             const { l, a: a2, b: b2 } = LAB.fromRgb(this.rgb);
             lightness = l;
@@ -68,28 +68,28 @@ export class LAB extends LABValues {
      * @param rgb The RGB(A) color to convert into LAB.
      */
     public static fromRgb(rgb: RGB): Partial<LABValues> {
-        if(rgb.isPureBlack) {
+        if (rgb.isPureBlack) {
             return { l: 0, a: 0, b: 0 };
         }
 
         let { r, g, b } = rgb.decimalValues;
 
-        r = (r > 0.04045) ? Math.pow((r + 0.055) / 1.055, 2.4) : r / 12.92;
-        g = (g > 0.04045) ? Math.pow((g + 0.055) / 1.055, 2.4) : g / 12.92;
-        b = (b > 0.04045) ? Math.pow((b + 0.055) / 1.055, 2.4) : b / 12.92;
+        r = r > 0.04045 ? Math.pow((r + 0.055) / 1.055, 2.4) : r / 12.92;
+        g = g > 0.04045 ? Math.pow((g + 0.055) / 1.055, 2.4) : g / 12.92;
+        b = b > 0.04045 ? Math.pow((b + 0.055) / 1.055, 2.4) : b / 12.92;
 
         let x = (r * 0.4124 + g * 0.3576 + b * 0.1805) / 0.95047;
-        let y = (r * 0.2126 + g * 0.7152 + b * 0.0722) / 1.00000;
+        let y = (r * 0.2126 + g * 0.7152 + b * 0.0722) / 1.0;
         let z = (r * 0.0193 + g * 0.1192 + b * 0.9505) / 1.08883;
 
-        x = (x > 0.008856) ? Math.pow(x, 1/3) : (7.787 * x) + 16 / 116;
-        y = (y > 0.008856) ? Math.pow(y, 1/3) : (7.787 * y) + 16 / 116;
-        z = (z > 0.008856) ? Math.pow(z, 1/3) : (7.787 * z) + 16 / 116;
+        x = x > 0.008856 ? Math.pow(x, 1 / 3) : 7.787 * x + 16 / 116;
+        y = y > 0.008856 ? Math.pow(y, 1 / 3) : 7.787 * y + 16 / 116;
+        z = z > 0.008856 ? Math.pow(z, 1 / 3) : 7.787 * z + 16 / 116;
 
         return {
-            l: fixedFloor((116 * y) - 16, 1),
+            l: fixedFloor(116 * y - 16, 1),
             a: fixedFloor(500 * (x - y), 1),
-            b: fixedFloor(200 * (y - z), 1)
+            b: fixedFloor(200 * (y - z), 1),
         };
     }
 
@@ -116,16 +116,20 @@ export class LAB extends LABValues {
         deltaH = deltaH < 0 ? 0 : Math.sqrt(deltaH);
         const sc = 1.0 + 0.045 * c1;
         const sh = 1.0 + 0.015 * c1;
-        const deltaLKlsl = deltaL / (1.0);
-        const deltaCkcsc = deltaC / (sc);
-        const deltaHkhsh = deltaH / (sh);
-        const i = deltaLKlsl * deltaLKlsl + deltaCkcsc * deltaCkcsc + deltaHkhsh * deltaHkhsh;
+        const deltaLKlsl = deltaL / 1.0;
+        const deltaCkcsc = deltaC / sc;
+        const deltaHkhsh = deltaH / sh;
+        const i =
+            deltaLKlsl * deltaLKlsl +
+            deltaCkcsc * deltaCkcsc +
+            deltaHkhsh * deltaHkhsh;
         return i < 0 ? 0 : Math.sqrt(i);
     }
 
     public toString(): string {
-        return `LAB(A) ( ${pad(this.l, 3)}%, ${pad(this.a, 3)}, ` +
-            `${pad(this.b, 3)}, ${pad(this.alpha, 3)} )`;
+        return (
+            `LAB(A) ( ${pad(this.l, 3)}%, ${pad(this.a, 3)}, ` +
+            `${pad(this.b, 3)}, ${pad(this.alpha, 3)} )`
+        );
     }
-
 }

--- a/src/color/lab.ts
+++ b/src/color/lab.ts
@@ -52,8 +52,11 @@ export class LAB extends LABValues {
             this.rgb = typeof arg0 === 'number' ? new RGB(arg0) : arg0;
             const { l, a: a2, b: b2 } = LAB.fromRgb(this.rgb);
             lightness = l;
+            // biome-ignore lint/style/noParameterAssign: Legacy
             a = a2;
+            // biome-ignore lint/style/noParameterAssign: Legacy
             b = b2;
+            // biome-ignore lint/style/noParameterAssign: Legacy
             alpha = this.rgb.alpha;
         }
 
@@ -74,17 +77,17 @@ export class LAB extends LABValues {
 
         let { r, g, b } = rgb.decimalValues;
 
-        r = r > 0.04045 ? Math.pow((r + 0.055) / 1.055, 2.4) : r / 12.92;
-        g = g > 0.04045 ? Math.pow((g + 0.055) / 1.055, 2.4) : g / 12.92;
-        b = b > 0.04045 ? Math.pow((b + 0.055) / 1.055, 2.4) : b / 12.92;
+        r = r > 0.04045 ? ((r + 0.055) / 1.055) ** 2.4 : r / 12.92;
+        g = g > 0.04045 ? ((g + 0.055) / 1.055) ** 2.4 : g / 12.92;
+        b = b > 0.04045 ? ((b + 0.055) / 1.055) ** 2.4 : b / 12.92;
 
         let x = (r * 0.4124 + g * 0.3576 + b * 0.1805) / 0.95047;
         let y = (r * 0.2126 + g * 0.7152 + b * 0.0722) / 1.0;
         let z = (r * 0.0193 + g * 0.1192 + b * 0.9505) / 1.08883;
 
-        x = x > 0.008856 ? Math.pow(x, 1 / 3) : 7.787 * x + 16 / 116;
-        y = y > 0.008856 ? Math.pow(y, 1 / 3) : 7.787 * y + 16 / 116;
-        z = z > 0.008856 ? Math.pow(z, 1 / 3) : 7.787 * z + 16 / 116;
+        x = x > 0.008856 ? x ** (1 / 3) : 7.787 * x + 16 / 116;
+        y = y > 0.008856 ? y ** (1 / 3) : 7.787 * y + 16 / 116;
+        z = z > 0.008856 ? z ** (1 / 3) : 7.787 * z + 16 / 116;
 
         return {
             l: fixedFloor(116 * y - 16, 1),

--- a/src/color/rgb.ts
+++ b/src/color/rgb.ts
@@ -37,16 +37,20 @@ export class RGB extends RGBValues {
         arg0: number,
         green?: number,
         blue?: number,
-        alpha: number = 255,
+        alpha = 255,
     ) {
         super('rgb');
         let red = arg0;
 
         if (green === undefined && blue === undefined) {
+            // biome-ignore lint/style/noParameterAssign: Legacy
             arg0 >>>= 0;
+            // biome-ignore lint/style/noParameterAssign: Legacy
             blue = arg0 & 0xff;
+            // biome-ignore lint/style/noParameterAssign: Legacy
             green = (arg0 & 0xff00) >>> 8;
             red = (arg0 & 0xff0000) >>> 16;
+            // biome-ignore lint/style/noParameterAssign: Legacy
             alpha = (arg0 & 0xff000000) >>> 24;
         }
 
@@ -78,10 +82,10 @@ export class RGB extends RGBValues {
         const { r: r1, g: g1, b: b1 } = this;
         const { r: r2, g: g2, b: b2 } = other;
 
-        const drp2 = Math.pow(r1 - r2, 2),
-            dgp2 = Math.pow(g1 - g2, 2),
-            dbp2 = Math.pow(b1 - b2, 2),
-            t = (r1 + r2) / 2;
+        const drp2 = (r1 - r2) ** 2;
+        const dgp2 = (g1 - g2) ** 2;
+        const dbp2 = (b1 - b2) ** 2;
+        const t = (r1 + r2) / 2;
 
         return Math.sqrt(
             2 * drp2 + 4 * dgp2 + 3 * dbp2 + (t * (drp2 - dbp2)) / 256,

--- a/src/color/rgb.ts
+++ b/src/color/rgb.ts
@@ -1,23 +1,18 @@
 import { Color } from './color';
 import { fixedFloor, pad } from '../util';
 
-
 export abstract class RGBValues extends Color<RGBValues> {
-
     public r: number;
     public g: number;
     public b: number;
 
     abstract toString();
-
 }
-
 
 /**
  * A color within the RGB color space.
  */
 export class RGB extends RGBValues {
-
     /**
      * Creates a new RGB(A) color instance from the given ARGB integer value.
      * @param argb The ARGB integer to convert to RGB(A).
@@ -31,18 +26,28 @@ export class RGB extends RGBValues {
      * @param blue The amount of blue in the color, from 0-255.
      * @param alpha [optional] The alpha value of the color, from 0-255. Defaults to 255, fully opaque.
      */
-    public constructor(red: number, green: number, blue: number, alpha?: number);
+    public constructor(
+        red: number,
+        green: number,
+        blue: number,
+        alpha?: number,
+    );
 
-    public constructor(arg0: number, green?: number, blue?: number, alpha: number = 255) {
+    public constructor(
+        arg0: number,
+        green?: number,
+        blue?: number,
+        alpha: number = 255,
+    ) {
         super('rgb');
         let red = arg0;
 
-        if(green === undefined && blue === undefined) {
+        if (green === undefined && blue === undefined) {
             arg0 >>>= 0;
-            blue = arg0 & 0xFF;
-            green = (arg0 & 0xFF00) >>> 8;
-            red = (arg0 & 0xFF0000) >>> 16;
-            alpha = (arg0 & 0xFF000000) >>> 24;
+            blue = arg0 & 0xff;
+            green = (arg0 & 0xff00) >>> 8;
+            red = (arg0 & 0xff0000) >>> 16;
+            alpha = (arg0 & 0xff000000) >>> 24;
         }
 
         this.r = red ?? 0;
@@ -56,10 +61,10 @@ export class RGB extends RGBValues {
      * @param other The new color to check against the current color.
      */
     public equals(other: RGB): boolean {
-        if(this.r !== other.r) {
+        if (this.r !== other.r) {
             return false;
         }
-        if(this.g !== other.g) {
+        if (this.g !== other.g) {
             return false;
         }
         return this.b === other.b;
@@ -76,9 +81,11 @@ export class RGB extends RGBValues {
         const drp2 = Math.pow(r1 - r2, 2),
             dgp2 = Math.pow(g1 - g2, 2),
             dbp2 = Math.pow(b1 - b2, 2),
-            t = (r1 + r2) / 2
+            t = (r1 + r2) / 2;
 
-        return Math.sqrt(2 * drp2 + 4 * dgp2 + 3 * dbp2 + t * (drp2 - dbp2) / 256);
+        return Math.sqrt(
+            2 * drp2 + 4 * dgp2 + 3 * dbp2 + (t * (drp2 - dbp2)) / 256,
+        );
     }
 
     /**
@@ -91,23 +98,23 @@ export class RGB extends RGBValues {
         this.g += other.g;
         this.b += other.b;
 
-        if(this.r > 255) {
+        if (this.r > 255) {
             this.r -= 255;
         }
-        if(this.g > 255) {
+        if (this.g > 255) {
             this.g -= 255;
         }
-        if(this.b > 255) {
+        if (this.b > 255) {
             this.b -= 255;
         }
 
-        if(this.r < 0) {
+        if (this.r < 0) {
             this.r += 255;
         }
-        if(this.g < 0) {
+        if (this.g < 0) {
             this.g += 255;
         }
-        if(this.b < 0) {
+        if (this.b < 0) {
             this.b += 255;
         }
     }
@@ -116,16 +123,27 @@ export class RGB extends RGBValues {
      * Calculates the hue value of this RGB(A) color.
      */
     public calculateHue(): number {
-        const { decimalValues: { r, g, b }, max, min } = this;
+        const {
+            decimalValues: { r, g, b },
+            max,
+            min,
+        } = this;
 
         let h = 0;
 
-        if(max !== min) { // achromatic otherwise
+        if (max !== min) {
+            // achromatic otherwise
             const delta = max - min;
-            switch(max) {
-                case r: h = (g - b) / delta + (g < b ? 6 : 0); break;
-                case g: h = (b - r) / delta + 2; break;
-                case b: h = (r - g) / delta + 4; break;
+            switch (max) {
+                case r:
+                    h = (g - b) / delta + (g < b ? 6 : 0);
+                    break;
+                case g:
+                    h = (b - r) / delta + 2;
+                    break;
+                case b:
+                    h = (r - g) / delta + 4;
+                    break;
             }
 
             h /= 6;
@@ -140,7 +158,7 @@ export class RGB extends RGBValues {
     public calculateSaturation(): number {
         const { max, min } = this;
 
-        if(max === min) {
+        if (max === min) {
             return 0; // achromatic
         }
 
@@ -150,8 +168,10 @@ export class RGB extends RGBValues {
     }
 
     public toString(): string {
-        return `RGB(A) ( ${pad(this.r, 3)}, ${pad(this.g, 3)}, ${pad(this.b, 3)}, ` +
-            `${pad(this.alpha, 3)})`;
+        return (
+            `RGB(A) ( ${pad(this.r, 3)}, ${pad(this.g, 3)}, ${pad(this.b, 3)}, ` +
+            `${pad(this.alpha, 3)})`
+        );
     }
 
     /**
@@ -183,7 +203,7 @@ export class RGB extends RGBValues {
      * `int[alpha << 24, red << 16, green << 8, blue]`
      */
     public get argb(): number {
-        return (this.alpha << 24) + (this.r << 16) + (this.g << 8) + (this.b);
+        return (this.alpha << 24) + (this.r << 16) + (this.g << 8) + this.b;
     }
 
     /**
@@ -194,7 +214,7 @@ export class RGB extends RGBValues {
         return this.values({
             r: this.r / 255,
             g: this.g / 255,
-            b: this.b / 255
+            b: this.b / 255,
         });
     }
 
@@ -203,11 +223,13 @@ export class RGB extends RGBValues {
      * `R:G:B / 255 * 100`
      */
     public get percentValues(): RGBValues {
-        const r = Math.floor(this.r / 255 * 100);
-        const g = Math.floor(this.g / 255 * 100);
-        const b = Math.floor(this.b / 255 * 100);
+        const r = Math.floor((this.r / 255) * 100);
+        const g = Math.floor((this.g / 255) * 100);
+        const b = Math.floor((this.b / 255) * 100);
         return this.values({
-            r, g, b
+            r,
+            g,
+            b,
         });
     }
 
@@ -239,7 +261,7 @@ export class RGB extends RGBValues {
      * The color's luminosity.
      */
     public get luminance(): number {
-        return  ((.2126 * this.r) + (.7152 * this.g) + (.0722 * this.b)) / 255;
+        return (0.2126 * this.r + 0.7152 * this.g + 0.0722 * this.b) / 255;
     }
 
     /**

--- a/src/compress/bzip2.ts
+++ b/src/compress/bzip2.ts
@@ -2,14 +2,13 @@ import { ByteBuffer } from '../buffer';
 import * as compressjs from 'compressjs';
 const bzip = compressjs.Bzip2;
 
-
 const charCode = (letter: string) => letter.charCodeAt(0);
 
-
 export class Bzip2 {
-
     public static compress(rawFileData: ByteBuffer): ByteBuffer {
-        const compressedFile = new ByteBuffer(bzip.compressFile(rawFileData, undefined, 1));
+        const compressedFile = new ByteBuffer(
+            bzip.compressFile(rawFileData, undefined, 1),
+        );
         // Do not include the BZip compression level header because the client expects a headerless BZip format
         return new ByteBuffer(compressedFile.slice(4, compressedFile.length));
     }
@@ -24,5 +23,4 @@ export class Bzip2 {
 
         return new ByteBuffer(bzip.decompressFile(buffer));
     }
-
 }

--- a/src/compress/bzip2.ts
+++ b/src/compress/bzip2.ts
@@ -4,6 +4,7 @@ const bzip = compressjs.Bzip2;
 
 const charCode = (letter: string) => letter.charCodeAt(0);
 
+// biome-ignore lint/complexity/noStaticOnlyClass: Legacy
 export class Bzip2 {
     public static compress(rawFileData: ByteBuffer): ByteBuffer {
         const compressedFile = new ByteBuffer(

--- a/src/compress/compression-method.ts
+++ b/src/compress/compression-method.ts
@@ -1,13 +1,15 @@
 export enum FileCompression {
     none = 0,
     bzip = 1,
-    gzip = 2
+    gzip = 2,
 }
 
 export type CompressionMethod = 'none' | 'bzip' | 'gzip';
 
-export const getCompressionMethod = (compression: FileCompression | number): CompressionMethod => {
-    if(compression === 0 || compression > 2) {
+export const getCompressionMethod = (
+    compression: FileCompression | number,
+): CompressionMethod => {
+    if (compression === 0 || compression > 2) {
         return 'none';
     }
 

--- a/src/compress/gzip.ts
+++ b/src/compress/gzip.ts
@@ -1,6 +1,7 @@
-import { gunzipSync, gzipSync } from 'zlib';
+import { gunzipSync, gzipSync } from 'node:zlib';
 import { ByteBuffer } from '../buffer';
 
+// biome-ignore lint/complexity/noStaticOnlyClass: Legacy
 export class Gzip {
     public static compress(buffer: ByteBuffer): ByteBuffer {
         return new ByteBuffer(gzipSync(buffer));

--- a/src/compress/gzip.ts
+++ b/src/compress/gzip.ts
@@ -1,9 +1,7 @@
 import { gunzipSync, gzipSync } from 'zlib';
 import { ByteBuffer } from '../buffer';
 
-
 export class Gzip {
-
     public static compress(buffer: ByteBuffer): ByteBuffer {
         return new ByteBuffer(gzipSync(buffer));
     }
@@ -11,5 +9,4 @@ export class Gzip {
     public static decompress(buffer: ByteBuffer): ByteBuffer {
         return new ByteBuffer(gunzipSync(buffer));
     }
-
 }

--- a/src/crc32/crc32.ts
+++ b/src/crc32/crc32.ts
@@ -1,16 +1,18 @@
 import { ByteBuffer } from '../buffer';
 
-
 export class Crc32 {
-
     public static crcLookupTable: number[] = new Array(256);
 
-    public static update(offset: number, size: number, data: ByteBuffer | Buffer | Uint8Array | number[]): number {
+    public static update(
+        offset: number,
+        size: number,
+        data: ByteBuffer | Buffer | Uint8Array | number[],
+    ): number {
         let crc = -1;
 
-        for(let currentByte = offset; currentByte < size; currentByte++) {
+        for (let currentByte = offset; currentByte < size; currentByte++) {
             const tableIndex = 0xff & (crc ^ data[currentByte]);
-            crc = this.crcLookupTable[tableIndex] ^ crc >>> 8;
+            crc = this.crcLookupTable[tableIndex] ^ (crc >>> 8);
         }
 
         crc ^= 0xffffffff;
@@ -18,19 +20,18 @@ export class Crc32 {
     }
 
     public static init(): void {
-        for(let i = 0; i < 256; i++) {
+        for (let i = 0; i < 256; i++) {
             let currentByte = i;
 
-            for(let bit = 0; bit < 8; bit++) {
-                if((currentByte & 0x1) !== 1) {
+            for (let bit = 0; bit < 8; bit++) {
+                if ((currentByte & 0x1) !== 1) {
                     currentByte >>>= 1;
                 } else {
-                    currentByte = -306674912 ^ currentByte >>> 1;
+                    currentByte = -306674912 ^ (currentByte >>> 1);
                 }
             }
 
             this.crcLookupTable[i] = currentByte;
         }
     }
-
 }

--- a/src/crc32/crc32.ts
+++ b/src/crc32/crc32.ts
@@ -1,5 +1,6 @@
-import { ByteBuffer } from '../buffer';
+import type { ByteBuffer } from '../buffer';
 
+// biome-ignore lint/complexity/noStaticOnlyClass: Legacy
 export class Crc32 {
     public static crcLookupTable: number[] = new Array(256);
 
@@ -12,7 +13,7 @@ export class Crc32 {
 
         for (let currentByte = offset; currentByte < size; currentByte++) {
             const tableIndex = 0xff & (crc ^ data[currentByte]);
-            crc = this.crcLookupTable[tableIndex] ^ (crc >>> 8);
+            crc = Crc32.crcLookupTable[tableIndex] ^ (crc >>> 8);
         }
 
         crc ^= 0xffffffff;
@@ -31,7 +32,7 @@ export class Crc32 {
                 }
             }
 
-            this.crcLookupTable[i] = currentByte;
+            Crc32.crcLookupTable[i] = currentByte;
         }
     }
 }

--- a/src/encrypt/encryption-method.ts
+++ b/src/encrypt/encryption-method.ts
@@ -1,8 +1,10 @@
 export enum FileEncryption {
     none = 0,
-    xtea = 1
+    xtea = 1,
 }
 
 export type EncryptionMethod = 'none' | 'xtea';
 
-export const getEncryptionMethod = (encryption: FileEncryption | number): EncryptionMethod => encryption === 1 ? 'xtea' : 'none';
+export const getEncryptionMethod = (
+    encryption: FileEncryption | number,
+): EncryptionMethod => (encryption === 1 ? 'xtea' : 'none');

--- a/src/encrypt/xtea.ts
+++ b/src/encrypt/xtea.ts
@@ -1,5 +1,5 @@
-import path from 'path';
-import fs from 'fs';
+import path from 'node:path';
+import fs from 'node:fs';
 
 import { logger } from '../logger';
 import { ByteBuffer } from '../buffer';
@@ -22,6 +22,7 @@ export interface XteaKeys {
 
 const toInt = (value) => value | 0;
 
+// biome-ignore lint/complexity/noStaticOnlyClass: Legacy
 export class Xtea {
     public static loadKeys(xteaConfigPath: string): Map<string, XteaKeys[]> {
         if (!fs.existsSync(xteaConfigPath)) {

--- a/src/encrypt/xtea.ts
+++ b/src/encrypt/xtea.ts
@@ -4,9 +4,7 @@ import fs from 'fs';
 import { logger } from '../logger';
 import { ByteBuffer } from '../buffer';
 
-
-export type XteaKey = [ number, number, number, number ];
-
+export type XteaKey = [number, number, number, number];
 
 export interface XteaConfig {
     archive: number;
@@ -17,66 +15,79 @@ export interface XteaConfig {
     key: XteaKey;
 }
 
-
 export interface XteaKeys {
     gameBuild: string;
     key: XteaKey;
 }
 
-
-const toInt = value => value | 0;
-
+const toInt = (value) => value | 0;
 
 export class Xtea {
-
     public static loadKeys(xteaConfigPath: string): Map<string, XteaKeys[]> {
-        if(!fs.existsSync(xteaConfigPath)) {
-            logger.error(`Error loading XTEA keys: ${xteaConfigPath} was not found.`);
+        if (!fs.existsSync(xteaConfigPath)) {
+            logger.error(
+                `Error loading XTEA keys: ${xteaConfigPath} was not found.`,
+            );
             return null;
         }
 
         const stats = fs.statSync(xteaConfigPath);
-        
-        if(!stats.isDirectory()) {
-            logger.error(`Error loading XTEA keys: ${xteaConfigPath} is not a directory.`);
+
+        if (!stats.isDirectory()) {
+            logger.error(
+                `Error loading XTEA keys: ${xteaConfigPath} is not a directory.`,
+            );
             return null;
         }
 
         const xteaKeys: Map<string, XteaKeys[]> = new Map<string, XteaKeys[]>();
         const xteaFileNames = fs.readdirSync(xteaConfigPath);
-        for(const fileName of xteaFileNames) {
+        for (const fileName of xteaFileNames) {
             try {
-                const gameBuild = fileName.substring(0, fileName.indexOf('.json'));
-                if(!gameBuild) {
-                    logger.error(`Error loading XTEA config file ${fileName}: No game version supplied.`);
+                const gameBuild = fileName.substring(
+                    0,
+                    fileName.indexOf('.json'),
+                );
+                if (!gameBuild) {
+                    logger.error(
+                        `Error loading XTEA config file ${fileName}: No game version supplied.`,
+                    );
                     continue;
                 }
 
-                const fileContent = fs.readFileSync(path.join(xteaConfigPath, fileName), 'utf-8');
+                const fileContent = fs.readFileSync(
+                    path.join(xteaConfigPath, fileName),
+                    'utf-8',
+                );
                 const xteaConfigList = JSON.parse(fileContent) as XteaConfig[];
 
-                if(!xteaConfigList?.length) {
-                    logger.error(`Error loading XTEA config file ${fileName}: File is empty.`);
+                if (!xteaConfigList?.length) {
+                    logger.error(
+                        `Error loading XTEA config file ${fileName}: File is empty.`,
+                    );
                     continue;
                 }
 
-                for(const xteaConfig of xteaConfigList) {
-                    if(!xteaConfig?.name || !xteaConfig?.key?.length) {
+                for (const xteaConfig of xteaConfigList) {
+                    if (!xteaConfig?.name || !xteaConfig?.key?.length) {
                         continue;
                     }
 
                     const { name: fileName, key } = xteaConfig;
                     let fileKeys: XteaKeys[] = [];
 
-                    if(xteaKeys.has(fileName)) {
+                    if (xteaKeys.has(fileName)) {
                         fileKeys = xteaKeys.get(fileName);
                     }
 
                     fileKeys.push({ gameBuild, key });
                     xteaKeys.set(fileName, fileKeys);
                 }
-            } catch(error) {
-                logger.error(`Error loading XTEA config file ${fileName}:`, error);
+            } catch (error) {
+                logger.error(
+                    `Error loading XTEA config file ${fileName}:`,
+                    error,
+                );
             }
         }
 
@@ -84,30 +95,39 @@ export class Xtea {
     }
 
     public static validKeys(keys?: number[] | undefined): boolean {
-        if(!keys) {
+        if (!keys) {
             return false;
         }
 
-        return keys?.length === 4 && (keys[0] !== 0 || keys[1] !== 0 || keys[2] !== 0 || keys[3] !== 0);
+        return (
+            keys?.length === 4 &&
+            (keys[0] !== 0 || keys[1] !== 0 || keys[2] !== 0 || keys[3] !== 0)
+        );
     }
 
     // @TODO unit testing
-    public static encrypt(input: ByteBuffer, keys: number[], length: number): ByteBuffer {
+    public static encrypt(
+        input: ByteBuffer,
+        keys: number[],
+        length: number,
+    ): ByteBuffer {
         const encryptedBuffer = new ByteBuffer(length);
         const chunks = length / 8;
         input.readerIndex = 0;
 
-        for(let i = 0; i < chunks; i++) {
+        for (let i = 0; i < chunks; i++) {
             let v0 = input.get('int');
             let v1 = input.get('int');
             let sum = 0;
             const delta = -0x61c88647;
 
             let rounds = 32;
-            while(rounds-- > 0) {
-                v0 += ((sum + keys[sum & 3]) ^ (v1 + ((v1 >>> 5) ^ (v1 << 4))));
-                sum += delta
-                v1 += ((v0 + ((v0 >>> 5) ^ (v0 << 4))) ^ (keys[(sum >>> 11) & 3] + sum));
+            while (rounds-- > 0) {
+                v0 += (sum + keys[sum & 3]) ^ (v1 + ((v1 >>> 5) ^ (v1 << 4)));
+                sum += delta;
+                v1 +=
+                    (v0 + ((v0 >>> 5) ^ (v0 << 4))) ^
+                    (keys[(sum >>> 11) & 3] + sum);
             }
 
             encryptedBuffer.put(v0, 'int');
@@ -118,26 +138,34 @@ export class Xtea {
     }
 
     // @TODO unit testing
-    public static decrypt(input: ByteBuffer, keys: number[], length: number): ByteBuffer {
-        if(!keys?.length) {
+    public static decrypt(
+        input: ByteBuffer,
+        keys: number[],
+        length: number,
+    ): ByteBuffer {
+        if (!keys?.length) {
             return input;
         }
 
         const output = new ByteBuffer(length);
         const numBlocks = Math.floor(length / 8);
 
-        for(let block = 0; block < numBlocks; block++) {
+        for (let block = 0; block < numBlocks; block++) {
             let v0 = input.get('int');
             let v1 = input.get('int');
-            let sum = 0x9E3779B9 * 32;
+            let sum = 0x9e3779b9 * 32;
 
-            for(let i = 0; i < 32; i++) {
-                v1 -= ((toInt(v0 << 4) ^ toInt(v0 >>> 5)) + v0) ^ (sum + keys[(sum >>> 11) & 3]);
+            for (let i = 0; i < 32; i++) {
+                v1 -=
+                    ((toInt(v0 << 4) ^ toInt(v0 >>> 5)) + v0) ^
+                    (sum + keys[(sum >>> 11) & 3]);
                 v1 = toInt(v1);
 
-                sum -= 0x9E3779B9;
+                sum -= 0x9e3779b9;
 
-                v0 -= ((toInt(v1 << 4) ^ toInt(v1 >>> 5)) + v1) ^ (sum + keys[sum & 3]);
+                v0 -=
+                    ((toInt(v1 << 4) ^ toInt(v1 >>> 5)) + v1) ^
+                    (sum + keys[sum & 3]);
                 v0 = toInt(v0);
             }
 
@@ -148,5 +176,4 @@ export class Xtea {
         input.copy(output, output.writerIndex, input.readerIndex);
         return output;
     }
-
 }

--- a/src/fs/file-util.ts
+++ b/src/fs/file-util.ts
@@ -1,6 +1,6 @@
-import util from 'util';
-import fs, { readFileSync } from 'fs';
-import { join } from 'path';
+import util from 'node:util';
+import fs, { readFileSync } from 'node:fs';
+import { join } from 'node:path';
 import { logger } from '../logger';
 
 const readdir = util.promisify(fs.readdir);
@@ -64,7 +64,7 @@ export async function* getFiles(
  * @param configurationDir The directory to search for configuration files.
  * @param filter [optional] The file filter to apply to this search.
  */
-export async function loadConfigurationFiles<T = any>(
+export async function loadConfigurationFiles<T>(
     configurationDir: string,
     filter?: FileFilter,
 ): Promise<T[]> {

--- a/src/fs/file-util.ts
+++ b/src/fs/file-util.ts
@@ -3,10 +3,8 @@ import fs, { readFileSync } from 'fs';
 import { join } from 'path';
 import { logger } from '../logger';
 
-
 const readdir = util.promisify(fs.readdir);
 const stat = util.promisify(fs.stat);
-
 
 /**
  * A whitelist or blacklist filter for file searching.
@@ -16,37 +14,41 @@ export interface FileFilter {
     list: string[];
 }
 
-
 /**
  * Searches for files within the given directory, using a FileFilter to filter the results if provided.
  * Returns an array of paths to the matching files so that they may be imported.
  * @param directory The directory to search for files.
  * @param filter [optional] The whitelist or blacklist filter to apply to the file search.
  */
-export async function* getFiles(directory: string, filter?: FileFilter): AsyncGenerator<string> {
+export async function* getFiles(
+    directory: string,
+    filter?: FileFilter,
+): AsyncGenerator<string> {
     const files = await readdir(directory);
 
-    for(const file of files) {
+    for (const file of files) {
         const path = join(directory, file);
         const statistics = await stat(path);
 
-        if(statistics.isDirectory()) {
+        if (statistics.isDirectory()) {
             for await (const child of getFiles(path, filter)) {
                 yield child;
             }
         } else {
-            if(filter?.type === 'blacklist') {
+            if (filter?.type === 'blacklist') {
                 // blacklist
-                const invalid = filter.list.some(item => file === item);
+                const invalid = filter.list.some((item) => file === item);
 
-                if(invalid) {
+                if (invalid) {
                     continue;
                 }
-            } else if(filter?.type === 'whitelist') {
+            } else if (filter?.type === 'whitelist') {
                 // whitelist
-                const invalid = !filter.list.some(item => file.endsWith(item));
+                const invalid = !filter.list.some((item) =>
+                    file.endsWith(item),
+                );
 
-                if(invalid) {
+                if (invalid) {
                     continue;
                 }
             }
@@ -56,24 +58,26 @@ export async function* getFiles(directory: string, filter?: FileFilter): AsyncGe
     }
 }
 
-
 /**
  * Searches the given directory for configuration files and converts the results into a
  * JSON array of the type T.
  * @param configurationDir The directory to search for configuration files.
  * @param filter [optional] The file filter to apply to this search.
  */
-export async function loadConfigurationFiles<T = any>(configurationDir: string, filter?: FileFilter): Promise<T[]> {
+export async function loadConfigurationFiles<T = any>(
+    configurationDir: string,
+    filter?: FileFilter,
+): Promise<T[]> {
     const files = [];
 
-    for await(const path of getFiles(configurationDir, filter)) {
+    for await (const path of getFiles(configurationDir, filter)) {
         try {
             const configContent = JSON.parse(readFileSync(path, 'utf8'));
 
-            if(configContent) {
+            if (configContent) {
                 files.push(configContent);
             }
-        } catch(error) {
+        } catch (error) {
             logger.error(`Error loading configuration file at ${path}:`);
             logger.error(error);
         }

--- a/src/logger/logger.ts
+++ b/src/logger/logger.ts
@@ -1,5 +1,5 @@
-import pino, { Logger, LoggerOptions, TimeFn } from 'pino';
-import SonicBoom from 'sonic-boom';
+import pino, { type Logger, type LoggerOptions, type TimeFn } from 'pino';
+import type SonicBoom from 'sonic-boom';
 
 export const LOGGER_DEFAULT_TIME_FN: true | TimeFn =
     pino.stdTimeFunctions.isoTime;
@@ -40,6 +40,7 @@ export class RuneLogger {
      * Log at `'log'` level the given messages.
      * @param messages The log messages to write.
      */
+    // biome-ignore lint/suspicious/noExplicitAny: Legacy
     public log(...messages: any[]): void {
         this.logMessages('log', ...messages);
     }
@@ -48,6 +49,7 @@ export class RuneLogger {
      * Log at `'info'` level the given messages.
      * @param messages The log messages to write.
      */
+    // biome-ignore lint/suspicious/noExplicitAny: Legacy
     public info(...messages: any[]): void {
         this.logMessages('info', ...messages);
     }
@@ -56,6 +58,7 @@ export class RuneLogger {
      * Log at `'debug'` level the given messages.
      * @param messages The log messages to write.
      */
+    // biome-ignore lint/suspicious/noExplicitAny: Legacy
     public debug(...messages: any[]): void {
         this.logMessages('debug', ...messages);
     }
@@ -64,6 +67,7 @@ export class RuneLogger {
      * Log at `'warn'` level the given messages.
      * @param messages The log messages to write.
      */
+    // biome-ignore lint/suspicious/noExplicitAny: Legacy
     public warn(...messages: any[]): void {
         this.logMessages('warn', ...messages);
     }
@@ -72,6 +76,7 @@ export class RuneLogger {
      * Log at `'error'` level the given messages.
      * @param messages The log messages to write.
      */
+    // biome-ignore lint/suspicious/noExplicitAny: Legacy
     public error(...messages: any[]): void {
         this.logMessages('error', ...messages);
     }
@@ -80,6 +85,7 @@ export class RuneLogger {
      * Log at `'trace'` level the given messages.
      * @param messages The log messages to write.
      */
+    // biome-ignore lint/suspicious/noExplicitAny: Legacy
     public trace(...messages: any[]): void {
         this.logMessages('trace', ...messages);
     }
@@ -88,6 +94,7 @@ export class RuneLogger {
      * Log at `'fatal'` level the given messages.
      * @param messages The log messages to write.
      */
+    // biome-ignore lint/suspicious/noExplicitAny: Legacy
     public fatal(...messages: any[]): void {
         this.logMessages('fatal', ...messages);
     }
@@ -140,8 +147,9 @@ export class RuneLogger {
         });
     }
 
+    // biome-ignore lint/suspicious/noExplicitAny: Legacy
     private logMessages(consoleType: string, ...args: any[]): void {
-        args.forEach((arg) => (this.pinoLogger[consoleType] as any)(arg));
+        args.forEach((arg) => this.pinoLogger[consoleType](arg));
     }
 
     private pinoInit(): void {

--- a/src/logger/logger.ts
+++ b/src/logger/logger.ts
@@ -1,8 +1,8 @@
 import pino, { Logger, LoggerOptions, TimeFn } from 'pino';
 import SonicBoom from 'sonic-boom';
 
-
-export const LOGGER_DEFAULT_TIME_FN: true | TimeFn = pino.stdTimeFunctions.isoTime;
+export const LOGGER_DEFAULT_TIME_FN: true | TimeFn =
+    pino.stdTimeFunctions.isoTime;
 
 /**
  * The main RuneJS wrapper class for the Pino logger.
@@ -10,7 +10,6 @@ export const LOGGER_DEFAULT_TIME_FN: true | TimeFn = pino.stdTimeFunctions.isoTi
  * @see https://www.npmjs.com/package/sonic-boom
  */
 export class RuneLogger {
-
     /**
      * The logger's active date/time format function for log messages.
      * IE timestamp: () => `,"time":"${new Date(Date.now()).toISOString()}"`
@@ -24,13 +23,13 @@ export class RuneLogger {
 
     private _options: LoggerOptions = {
         timestamp: this.loggerTimeFn,
-        prettyPrint: true
+        prettyPrint: true,
     };
 
     private _boom: SonicBoom;
 
     public constructor(options?: LoggerOptions) {
-        if(options) {
+        if (options) {
             this._options = options;
         }
 
@@ -109,7 +108,7 @@ export class RuneLogger {
      * @param options The options to supply to the `pino` logger instance.
      */
     public setOptions(options: LoggerOptions): void {
-        if(!options.timestamp) {
+        if (!options.timestamp) {
             options.timestamp = LOGGER_DEFAULT_TIME_FN;
         }
 
@@ -126,7 +125,7 @@ export class RuneLogger {
     public setPrettyPrint(prettyPrint: boolean): void {
         this.setOptions({
             timestamp: this.loggerTimeFn,
-            prettyPrint
+            prettyPrint,
         });
     }
 
@@ -137,12 +136,12 @@ export class RuneLogger {
      */
     public setTimeFormat(format: TimeFn) {
         this.setOptions({
-            timestamp: format
+            timestamp: format,
         });
     }
 
     private logMessages(consoleType: string, ...args: any[]): void {
-        args.forEach(arg => (this.pinoLogger[consoleType] as any)(arg));
+        args.forEach((arg) => (this.pinoLogger[consoleType] as any)(arg));
     }
 
     private pinoInit(): void {
@@ -156,9 +155,7 @@ export class RuneLogger {
     public get options(): LoggerOptions {
         return this._options;
     }
-
 }
-
 
 /**
  * The main logger singleton instance.

--- a/src/net/connection-status.ts
+++ b/src/net/connection-status.ts
@@ -1,5 +1,5 @@
 export enum ConnectionStatus {
     HANDSHAKE = 'handshake',
     ACTIVE = 'active',
-    CLOSED = 'closed'
+    CLOSED = 'closed',
 }

--- a/src/net/server-config.ts
+++ b/src/net/server-config.ts
@@ -3,9 +3,7 @@ import * as fs from 'fs';
 import { JSON_SCHEMA, safeLoad } from 'js-yaml';
 import { logger } from '../logger';
 
-
 export type ConfigFileFormat = 'json' | 'yaml';
-
 
 export interface ServerConfigOptions {
     useDefault?: boolean;
@@ -15,25 +13,25 @@ export interface ServerConfigOptions {
     configFileName?: string;
 }
 
-
 export const defaults: ServerConfigOptions = {
     configDir: path.join('.', 'config'),
     cacheDir: path.join('.', 'cache'),
     filestoreDir: path.join('.', 'filestore'),
-    configFileName: 'server-config'
+    configFileName: 'server-config',
 };
 
-
-export const sanitizeConfigOptions = (options?: ServerConfigOptions): ServerConfigOptions => {
-    if(!options) {
+export const sanitizeConfigOptions = (
+    options?: ServerConfigOptions,
+): ServerConfigOptions => {
+    if (!options) {
         options = {
-            useDefault: false
+            useDefault: false,
         };
     }
 
     const keys = Object.keys(defaults);
-    for(const propName of keys) {
-        if(!options[propName]) {
+    for (const propName of keys) {
+        if (!options[propName]) {
             options[propName] = defaults[propName];
         }
     }
@@ -41,40 +39,43 @@ export const sanitizeConfigOptions = (options?: ServerConfigOptions): ServerConf
     return options;
 };
 
-
 export function parseServerConfig<T>(options?: ServerConfigOptions): T {
     options = sanitizeConfigOptions(options);
 
     let filePath = path.join(options.configDir, options.configFileName);
-    if(options.useDefault) {
+    if (options.useDefault) {
         filePath += '.example';
     }
 
     let fileType: ConfigFileFormat | undefined;
 
-    if(fs.existsSync(`${filePath}.json`)) {
+    if (fs.existsSync(`${filePath}.json`)) {
         fileType = 'json';
-    } else if(fs.existsSync(`${filePath}.yaml`)) {
+    } else if (fs.existsSync(`${filePath}.yaml`)) {
         fileType = 'yaml';
     } else {
-        if(!options.useDefault) {
+        if (!options.useDefault) {
             logger.warn(`Server config not provided, using default...`);
             return parseServerConfig({ useDefault: true });
         } else {
-            throw new Error(`Unable to load server configuration: Default (.example) server configuration file not found.`);
+            throw new Error(
+                `Unable to load server configuration: Default (.example) server configuration file not found.`,
+            );
         }
     }
 
     filePath += `.${fileType}`;
 
     const configFileContent = fs.readFileSync(filePath, 'utf-8');
-    if(!configFileContent) {
-        throw new Error(`Syntax error encountered while loading server configuration file.`);
+    if (!configFileContent) {
+        throw new Error(
+            `Syntax error encountered while loading server configuration file.`,
+        );
     }
 
-    if(fileType === 'json') {
+    if (fileType === 'json') {
         options = JSON.parse(configFileContent) as T;
-    } else if(fileType === 'yaml') {
+    } else if (fileType === 'yaml') {
         options = safeLoad(configFileContent, { schema: JSON_SCHEMA }) as T;
     }
 

--- a/src/test.ts
+++ b/src/test.ts
@@ -1,22 +1,22 @@
 import { SocketServer } from './net';
 import { ByteBuffer } from './buffer';
 import { logger } from './index';
-import { Socket } from 'net';
+import { Socket } from 'node:net';
 
 class TestConnectionHandler extends SocketServer {
     public decodeMessage(data: ByteBuffer): void {
-        logger.info(`Data received:`, data.get('string'));
+        logger.info('Data received:', data.get('string'));
         logger.info(data.get('long').toString());
     }
 
     public initialHandshake(data: ByteBuffer): boolean {
-        logger.info(`Initial handshake:`, data.get('string'));
+        logger.info('Initial handshake:', data.get('string'));
         logger.info(data.get('long').toString());
         return true;
     }
 
     public connectionDestroyed(): void {
-        logger.info(`Connection destroyed.`);
+        logger.info('Connection destroyed.');
     }
 }
 

--- a/src/test.ts
+++ b/src/test.ts
@@ -3,9 +3,7 @@ import { ByteBuffer } from './buffer';
 import { logger } from './index';
 import { Socket } from 'net';
 
-
 class TestConnectionHandler extends SocketServer {
-
     public decodeMessage(data: ByteBuffer): void {
         logger.info(`Data received:`, data.get('string'));
         logger.info(data.get('long').toString());
@@ -20,7 +18,6 @@ class TestConnectionHandler extends SocketServer {
     public connectionDestroyed(): void {
         logger.info(`Connection destroyed.`);
     }
-
 }
 
 function launchTestServer() {
@@ -28,12 +25,17 @@ function launchTestServer() {
 
     const TEST_PORT = 8000;
 
-    const server = SocketServer.launch('Test Server', '0.0.0.0', TEST_PORT, socket =>
-        new TestConnectionHandler(socket, {
-            timeout: 300,
-            keepAlive: false,
-            handshakeRequired: false
-        }));
+    const server = SocketServer.launch(
+        'Test Server',
+        '0.0.0.0',
+        TEST_PORT,
+        (socket) =>
+            new TestConnectionHandler(socket, {
+                timeout: 300,
+                keepAlive: false,
+                handshakeRequired: false,
+            }),
+    );
 
     const speakySocket = new Socket();
     speakySocket.connect(TEST_PORT);

--- a/src/util/foreach-async.ts
+++ b/src/util/foreach-async.ts
@@ -1,29 +1,47 @@
 declare global {
     interface Array<T> {
-        forEachAsync<U = void>(callback: (entry: T) => Promise<U>): Promise<U[]>;
+        forEachAsync<U = void>(
+            callback: (entry: T) => Promise<U>,
+        ): Promise<U[]>;
     }
 
     interface Map<K, V> {
-        forEachAsync<U = void>(callback: (value: V, key: K, map: Map<K, V>) => Promise<U>): Promise<U[]>;
+        forEachAsync<U = void>(
+            callback: (value: V, key: K, map: Map<K, V>) => Promise<U>,
+        ): Promise<U[]>;
     }
 }
 
-Array.prototype.forEachAsync = async function<T, U = void>(callback: (entry: T) => Promise<U>): Promise<U[]> {
-    if(this === undefined || this === null || !Array.isArray(this) || this.length < 1) {
+Array.prototype.forEachAsync = async function <T, U = void>(
+    callback: (entry: T) => Promise<U>,
+): Promise<U[]> {
+    if (
+        this === undefined ||
+        this === null ||
+        !Array.isArray(this) ||
+        this.length < 1
+    ) {
         return;
     }
 
     return await Promise.all(this.map(callback));
 };
 
-Map.prototype.forEachAsync = async function<K, V, U = void>(callback: (value: V, key: K, map: Map<K, V>) => Promise<U>): Promise<U[]> {
-    if(this === undefined || this === null || !(this instanceof Map) || this.size < 1) {
+Map.prototype.forEachAsync = async function <K, V, U = void>(
+    callback: (value: V, key: K, map: Map<K, V>) => Promise<U>,
+): Promise<U[]> {
+    if (
+        this === undefined ||
+        this === null ||
+        !(this instanceof Map) ||
+        this.size < 1
+    ) {
         return;
     }
 
     const promises = new Array(this.size);
     let i = 0;
-    for(const [ key, value ] of this) {
+    for (const [key, value] of this) {
         promises[i++] = callback(value, key, this);
     }
 

--- a/src/util/numbers.ts
+++ b/src/util/numbers.ts
@@ -1,9 +1,9 @@
 export const fixedFloor = (i: number, fractionDigits: number = 0): number => {
-    if(isNaN(i) || i < 0) {
+    if (isNaN(i) || i < 0) {
         return 0;
     }
 
-    if(fractionDigits === 0) {
+    if (fractionDigits === 0) {
         return Math.floor(i);
     } else {
         return Number(i.toFixed(fractionDigits));

--- a/src/util/numbers.ts
+++ b/src/util/numbers.ts
@@ -1,11 +1,11 @@
-export const fixedFloor = (i: number, fractionDigits: number = 0): number => {
-    if (isNaN(i) || i < 0) {
+export const fixedFloor = (i: number, fractionDigits = 0): number => {
+    if (Number.isNaN(i) || i < 0) {
         return 0;
     }
 
     if (fractionDigits === 0) {
         return Math.floor(i);
-    } else {
-        return Number(i.toFixed(fractionDigits));
     }
+
+    return Number(i.toFixed(fractionDigits));
 };

--- a/src/util/objects.ts
+++ b/src/util/objects.ts
@@ -1,7 +1,7 @@
 export function setObjectProps<T>(
     object: T,
     objectProps: Map<string, unknown> | Partial<T> | undefined,
-    ignoreFieldNameCase: boolean = false,
+    ignoreFieldNameCase = false,
 ): void {
     if (!objectProps) {
         return;
@@ -17,9 +17,9 @@ export function setObjectProps<T>(
         const existingKey = objectKeys.find((k) => {
             if (ignoreFieldNameCase) {
                 return k.toLowerCase() === key.toLowerCase();
-            } else {
-                return k === key;
             }
+
+            return k === key;
         });
 
         if (existingKey) {

--- a/src/util/objects.ts
+++ b/src/util/objects.ts
@@ -1,26 +1,36 @@
-export function setObjectProps<T>(object: T,
-                                  objectProps: Map<string, unknown> | Partial<T> | undefined,
-                                  ignoreFieldNameCase: boolean = false): void {
-    if(!objectProps) {
+export function setObjectProps<T>(
+    object: T,
+    objectProps: Map<string, unknown> | Partial<T> | undefined,
+    ignoreFieldNameCase: boolean = false,
+): void {
+    if (!objectProps) {
         return;
     }
 
-    const dataKeys = objectProps instanceof Map ? Array.from(objectProps.keys()) :
-        Object.keys(objectProps ?? {});
+    const dataKeys =
+        objectProps instanceof Map
+            ? Array.from(objectProps.keys())
+            : Object.keys(objectProps ?? {});
     const objectKeys = Object.keys(object);
 
-    dataKeys.forEach(key => {
-        const existingKey = objectKeys.find(k => {
-            if(ignoreFieldNameCase) {
+    dataKeys.forEach((key) => {
+        const existingKey = objectKeys.find((k) => {
+            if (ignoreFieldNameCase) {
                 return k.toLowerCase() === key.toLowerCase();
             } else {
                 return k === key;
             }
         });
 
-        if(existingKey) {
-            const value = objectProps instanceof Map ? objectProps.get(key) : objectProps[key];
-            if(typeof object[existingKey] === 'number' || /^\d*$/.test(value)) {
+        if (existingKey) {
+            const value =
+                objectProps instanceof Map
+                    ? objectProps.get(key)
+                    : objectProps[key];
+            if (
+                typeof object[existingKey] === 'number' ||
+                /^\d*$/.test(value)
+            ) {
                 object[existingKey] = Number(value);
             } else {
                 object[existingKey] = value;

--- a/src/util/strings.ts
+++ b/src/util/strings.ts
@@ -5,60 +5,63 @@ export interface PadOptions {
     hideEmpties?: boolean;
 }
 
-
-export const pad = (value: number, paddingAmount: number, options?: PadOptions): string => {
-    if(!options) {
+export const pad = (
+    value: number,
+    paddingAmount: number,
+    options?: PadOptions,
+): string => {
+    if (!options) {
         options = {};
     }
 
     let { char, direction, fractionDigits, hideEmpties } = options;
-    if(char === undefined) {
+    if (char === undefined) {
         char = ' ';
     }
-    if(!direction || (direction !== 'left' && direction !== 'right')) {
+    if (!direction || (direction !== 'left' && direction !== 'right')) {
         direction = 'left';
     }
-    if(fractionDigits === undefined) {
+    if (fractionDigits === undefined) {
         fractionDigits = 0;
     }
-    if(hideEmpties === undefined) {
+    if (hideEmpties === undefined) {
         hideEmpties = false;
     }
 
-    if(value === 0 && hideEmpties) {
+    if (value === 0 && hideEmpties) {
         return new Array(paddingAmount).fill(char).join('');
     }
 
     const stringified = `${value}`;
     const parts = stringified.split('.');
-    if(!parts?.length) {
+    if (!parts?.length) {
         return 'NaN';
     }
 
     let wholeNumber = parts[0];
     const wholeNumberDelta = paddingAmount - wholeNumber.length;
 
-    if(wholeNumberDelta > 0) {
+    if (wholeNumberDelta > 0) {
         const fill = new Array(wholeNumberDelta).fill(char).join('');
-        if(direction === 'left') {
+        if (direction === 'left') {
             wholeNumber = fill + wholeNumber;
         } else {
             wholeNumber += fill;
         }
     }
 
-    if(fractionDigits === 0) {
+    if (fractionDigits === 0) {
         return wholeNumber;
     }
 
-    if(parts.length !== 2) {
+    if (parts.length !== 2) {
         parts.push('');
     }
 
     let fractional = parts[1];
     const fractionalDelta = fractionDigits - fractional.length;
 
-    if(fractionalDelta > 0) {
+    if (fractionalDelta > 0) {
         fractional += new Array(fractionalDelta).fill('0');
     }
 

--- a/src/util/strings.ts
+++ b/src/util/strings.ts
@@ -8,12 +8,8 @@ export interface PadOptions {
 export const pad = (
     value: number,
     paddingAmount: number,
-    options?: PadOptions,
+    options: PadOptions = {},
 ): string => {
-    if (!options) {
-        options = {};
-    }
-
     let { char, direction, fractionDigits, hideEmpties } = options;
     if (char === undefined) {
         char = ' ';

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,10 +13,8 @@
         "allowJs": true,
         "declaration": true,
         "outDir": "./lib",
-        "types": [
-            "node"
-        ]
+        "types": ["node"]
     },
-    "include": [ "src/" ],
-    "exclude": [ "!src/" ]
+    "include": ["src/"],
+    "exclude": ["!src/"]
 }


### PR DESCRIPTION
Removes the ESLint package and project and replaces it with Biome to handle both formatting and linting.

I've modified the Biome config to use single quotes and 4 space indentation so as to minimise noise in the diff.

I updated Typescript, tslib and Node typings as these were drop in without any code updates required (nice).

I replaced `ts-node-dev` with `ts-node` to fix the `start` script (tested and working as well!)